### PR TITLE
Polishing JVM documentation

### DIFF
--- a/services/grails-service-bindings.html.md
+++ b/services/grails-service-bindings.html.md
@@ -53,8 +53,8 @@ The best way to do the manual configuration is to use the `spring-cloud` library
   }
 
   dependencies {
-    compile "org.springframework.cloud:cloudfoundry-connector:1.0.2"
-    compile "org.springframework.cloud:spring-service-connector:1.0.2"
+    compile "org.springframework.cloud:cloudfoundry-connector:0.9.5"
+    compile "org.springframework.cloud:spring-service-connector:0.9.5"
   }
 ```
 

--- a/services/spring-service-bindings.html.md
+++ b/services/spring-service-bindings.html.md
@@ -37,12 +37,12 @@ dependency.
 	<dependency>
 	    <groupId>org.springframework.cloud</groupId>
 	    <artifactId>cloudfoundry-connector</artifactId>
-	    <version>1.0.2</version>
+	    <version>0.9.5</version>
 	</dependency>
 	<dependency>
 	    <groupId>org.springframework.cloud</groupId>
 	    <artifactId>spring-service-connector</artifactId>
-	    <version>1.0.2</version>
+	    <version>0.9.5</version>
 	 </dependency>
 </dependencies>
 ```


### PR DESCRIPTION
Previously the wrong version numbers were used in a couple of JVM examples.  This change fixes those version numbers so that they are accurate.

[#64675106]
