### PR TITLE
fix create-domain example

### DIFF
--- a/deploy-apps/domains-routes.html.md.erb
+++ b/deploy-apps/domains-routes.html.md.erb
@@ -120,7 +120,7 @@ Use the `-n HOSTNAME` parameter with the `create-domain` command to specify a un
 	"test-org" organization:
 
 	<pre class="terminal">
-	$ cf create-domain test-org example.org -n myapp
+	$ cf create-domain test-org example.org
 	</pre>
 
  1. Map the route to your app:
@@ -142,7 +142,7 @@ Use the `-n HOSTNAME` parameter with the `create-domain` command to specify a un
 		</tr>
 		<tr>
 		  <td>CNAME</td>
-		  <td>test</td>
+		  <td>myapp</td>
 		  <td>yourappname.<%=vars.app_domain%>.</td>
 		  <td>Refer to your DNS provider documentation to determine whether the trailing `.` is required.</td>
 		</tr>


### PR DESCRIPTION
create-domain does not take a -n argument, rather it is only done on the map-route. Also aligned the example app name, "myapp" with what is shown in the CNAME record.
