### PR TITLE
Update documentation arounf syslog drain binding

### DIFF
--- a/services/log-management-thirdparty-svc.html.md.erb
+++ b/services/log-management-thirdparty-svc.html.md.erb
@@ -35,7 +35,7 @@ From your Papertrail account:
 
     `$ cf cups my-logs -l syslog://logs.papertrailapp.com:<port>`
 
-1. Bind the service to an app, then restart or re-stage as necessary.
+1. Bind the service to an app. Logs will begin to flow automatically after a short delay.
 
 1. Once Papertrail starts receiving log entries, the view automatically updates
 to the logs viewing page.
@@ -72,7 +72,7 @@ assigns to outbound traffic. If you are using Pivotal Web Services,
 
     `$ cf cups my-logs -l syslog://<host:port>`
 
-1. Bind the service to an app, then restart or re-stage as necessary.
+1. Bind the service to an app. Logs will begin to flow automatically after a short delay.
 
 1. Wait for some events to appear, then click **Data Summary**.
 
@@ -118,7 +118,7 @@ source.
 
     `$ cf cups my-logs -l <HTTP SOURCE-URL>`
 
-1. Bind the service to an app, then restart or re-stage as necessary.
+1. Bind the service to an app. Logs will begin to flow automatically after a short delay.
 
 1. In the SumoLogic dashboard, click **Manage**, then click **Status** to see a
 view of log messages received over time.

--- a/services/log-management.html.md.erb
+++ b/services/log-management.html.md.erb
@@ -78,7 +78,7 @@ Refer to the [User-Provided Services](./user-provided.html#user-cups) topic for 
 You have two options:
 
 * Use `cf push` with a manifest. The services block in the manifest must specify the service instance that you want to bind.
-* Use `cf bind-service` followed by `cf push`.
+* Use `cf bind-service`. Logs will begin to flow automatically after a short delay.
 
 See [Binding User-Provided Service Instances to Applications](user-provided.html#cups-example).
 

--- a/services/user-provided.html.md.erb
+++ b/services/user-provided.html.md.erb
@@ -74,7 +74,7 @@ There are two ways to bind user-provided service instances to applications:
 * With a manifest, _when_ you push the application.
 * With the `cf bind-service` command, _after_ you push the application.
 
-In either case, you must push your app to a space where the desired user-provided instances already exist.
+In either case, you must push your app to a space where the desired user-provided instances already exist. (This does not apply to binding log drains; they automatically activate after a short delay.)
 
 For example, if you want to bind a service instance called `test-mysql-01` to an app, the services block in the manifest should look like this:
 


### PR DESCRIPTION
Binding syslog drains no longer requires a push/restage.

[#83686174]

Signed-off-by: Nick Wade nwade@pivotal.io
