### PR TITLE
Changes in attribute used in the manifest.

### DIFF
--- a/deploy-apps/manifest.html.md.erb
+++ b/deploy-apps/manifest.html.md.erb
@@ -427,7 +427,7 @@ applications:
   host: tock09876
   path: ./spring-music/build/libs/spring-music.war
 - name: springtick
-  subdomain: tick09875
+  host: tick09875
   path: ./spring-music/build/libs/spring-music.war
 </pre>
 
@@ -475,7 +475,7 @@ applications:
    host: 765shower
    path: ./april/build/libs/april-weather.war
  - name: wintertick
-   subdomain: 321flurry
+   host: 321flurry
    path: ./december/target/december-weather.war
 </pre>
 


### PR DESCRIPTION
Replaced 'subdomain' attribute used in manifest examples to 'host'.
Issue : https://github.com/cloudfoundry/docs-dev-guide/issues/34