### PR TITLE
this security warning no longer appears

### DIFF
--- a/installcf/install-go-cli.html.md.erb
+++ b/installcf/install-go-cli.html.md.erb
@@ -29,9 +29,6 @@ To install the cf CLI on Windows:
 1. Select an install destination and click **Continue**.
 1. When prompted, click **Install**.
 
-<p class='note'><strong>Note</strong>: If you are using the default Security Settings on your machine, a signing issue appears when you download the <code>.pkg</code> file.
-Refer to the <a href='https://support.apple.com/en-gb/HT202491'>Apple documentation</a> for instructions for resolving this issue.</p>
-
 ## <a id="next-steps"></a>Next Steps ##
 To verify your installation, open a terminal window and type `cf`.
 If your installation was successful, the cf CLI help listing appears.


### PR DESCRIPTION
Since cf CLI v6.14.1 (released 23 Dec 2015) we digitally sign the Mac OS X installer so this warning no longer appears.