### PR TITLE
add routes attribute to app manifest deployment

### DIFF
--- a/deploy-apps/manifest.html.md.erb
+++ b/deploy-apps/manifest.html.md.erb
@@ -319,6 +319,62 @@ By default, if you do not provide a hostname, the URL for the app takes the form
 
 The command line option that corresponds to this attribute is `--no-hostname`.
 
+###<a id='routes'></a>The routes attribute ###
+
+Use the `routes` attribute to provide multiple HTTP and TCP routes. Each route for this app is created if it does not already exist.
+
+This attribute is a combination of `push` options that include `--hostname`, `-d`, and `--route-path`.
+
+<pre>
+---
+  ...
+  routes:
+  - route: example.com
+  - route: www.example.com/foo
+  - route: tcp-example.com:1234
+</pre>
+
+#### Manifest Attributes
+The `routes` attribute cannot be used in conjunction with the following attributes: `host`, `hosts`, `domain`, `domains`, and `no-hostname`. An error will result.
+
+#### Push Flag Options
+This attribute has unique interactions with different command line options.
+<table border="1" class="nice" >
+<tr>
+<th>Push Flag Option</th>
+<th>Resulting Behaviour</th>
+</tr>
+<tr>
+<td><code>--no-route</code></td>
+<td>All declared routes are ignored.</td>
+</tr>
+<td><code>-d</code></td>
+<td>Overrides DOMAIN part of all declared HTTP and TCP routes.</td>
+</tr>
+<tr>
+<td><code>--hostname, -n</code></td>
+<td>Sets or overrides HOSTNAME in all HTTP routes. <br />
+It has no impact on TCP routes.</td>
+</tr>
+<tr>
+<td><code>--no-hostname</code></td>
+<td>This suppresses creation of a default hostname.<br />
+It has no impact on TCP routes.</td>
+</tr>
+<tr>
+<td><code>--route-path</code></td>
+<td>Sets or overrides the PATH in all HTTP routes.<br />
+It has no impact on TCP routes.</td>
+</tr>
+<tr>
+<td><code>--random-route</code></td>
+<td>Sets or overrides the HOSTNAME in all HTTP routes.<br />
+Sets or overrides the PORT in all TCP routes.<br />
+The PORT and HOSTNAME will be randomly generated.</td>
+</tr>
+<tr>
+</table>
+
 ###<a id='random-route'></a>The random-route attribute ###
 
 Use the `random-route` attribute to create a URL that includes the app name and


### PR DESCRIPTION
We added an additional section in [here](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html) to describe a newly released feature that allows application routes in the app manifest.

Story in the CF-CLI tracker [#121917921](https://www.pivotaltracker.com/story/show/121917921)
