### PR TITLE
Add warning about .profile issues in PHP Buildpack

### DIFF
--- a/deploy-apps/deploy-app.html.md.erb
+++ b/deploy-apps/deploy-app.html.md.erb
@@ -185,6 +185,8 @@ Because the `.profile` script executes after the buildpack, the script also has 
 
 <p class="note"><strong>Note</strong>: Your application root directory may also include a <code>.profile.d</code> directory that contains bash scripts that perform initialization tasks for the buildpack. Developers should not edit these scripts unless they are using a <a href="../../buildpacks/custom.html">custom buildpack</a>.</p>
 
+<p class="note"><strong>Warning for PHP buildpack v4.3.18 and before</strong>: The PHP Buildpack will not execute your PHP app's <code>`.profile`</code> script. Also, your PHP app will host the <code>.profile</code> script's contents.</p>
+
 ## <a id='push'></a>Step 5: Push the Application ##
 
 Run the following command to deploy an application without a manifest:


### PR DESCRIPTION
- PHP Buildpack will not execute .profile scripts
- PHP apps staged with the buildpack will host the .profile script

[#128244503]

Signed-off-by: James Wen <jrw2175@columbia.edu>