### PR TITLE
Fix typo in VCAP_APPLICATION example

### DIFF
--- a/deploy-apps/environment-variable.html.md.erb
+++ b/deploy-apps/environment-variable.html.md.erb
@@ -257,7 +257,7 @@ VCAP_APPLICATION={"instance_id":"fe98dc76ba549876543210abcd1234",
 +0000","state_timestamp":1376265929,"limits":{"mem":512,"disk":1024,"fds":16384}
 ,"application_version":"ab12cd34-5678-abcd-0123-abcdef987654","application_name"
 :"styx-james","application_uris":["styx-james.a1-app.cf-app.com"],"version":"ab1
-2cd34-5678-abcd-0123-abcdef987654","name":"my-app","uris":["my-app.example.com"]
+2cd34-5678-abcd-0123-abcdef987654","name":"my-app","uris":["styx-james.a1-app.cf-app.com"]
 ,"users":null}
 ~~~
 


### PR DESCRIPTION
The example VCAP_APPLICATION's application_uris and uris arrays should be the same, as described.