### PR TITLE
Clarify roles in SSH docs.

### DIFF
--- a/deploy-apps/app-ssh-overview.html.md.erb
+++ b/deploy-apps/app-ssh-overview.html.md.erb
@@ -13,7 +13,7 @@ For example, one of your app instances may be unresponsive, or the log output fr
 
 ## <a id="ssh-access-control-hierarchy"></a>SSH Access Control Hierarchy
 
-Operators, space administrators, and developers can configure SSH access for <%= vars.product_short %>, spaces, and apps as described in this table:
+Operators, space managers, and space developers can configure SSH access for <%= vars.product_short %>, spaces, and apps as described in this table:
 
 <table id='TK-NAME' border="1" class="nice" >
   <tr>
@@ -25,28 +25,28 @@ Operators, space administrators, and developers can configure SSH access for <%=
     <td>Entire deployment</td>
     <td>Configure the deployment to allow or prohibit SSH access (one-time)</td>
   </tr><tr>
-    <td>Space Administrator</td>
+    <td>Space Manager</td>
     <td>Space</td>
     <td>cf CLI <a href="http://cli.cloudfoundry.org/en-US/cf/allow-space-ssh.html">allow-space-ssh</a> and <a href="http://cli.cloudfoundry.org/en-US/cf/disallow-space-ssh.html">disallow-space-ssh</a> commands</td>
   </tr><tr>
-    <td>Developer</td>
+    <td>Space Developer</td>
     <td>Application</td>
     <td>cf CLI <a href="http://cli.cloudfoundry.org/en-US/cf/enable-ssh.html">enable-ssh</a> and <a href="http://cli.cloudfoundry.org/en-US/cf/disable-ssh.html">disable-ssh</a> commands</td>
   </tr>
 </table>
 
-An application is SSH-accessible only if operators, space administrators, and developers all grant SSH access at their respective levels. For example, the image below shows a deployment where:
+An application is SSH-accessible only if operators, space managers, and space developers all grant SSH access at their respective levels. For example, the image below shows a deployment where:
 
 * An operator allowed SSH access at the deployment level.
-* A space administrator allowed SSH access for applications running in spaces "A" and "B" but not "C."
-* A developer enabled SSH access for applications that include "Foo," "Bar," and "Baz."
+* A space manager allowed SSH access for applications running in spaces "A" and "B" but not "C."
+* A space developer enabled SSH access for applications that include "Foo," "Bar," and "Baz."
 
 As a result, apps "Foo," "Bar," and "Baz" accept SSH requests.
 
 <%= image_tag("../images/ssh-app-access.png") %>
 
 ## <a id='app-ssh-config'></a>SSH Access for Apps and Spaces
-Administrators and application developers can configure SSH access from the command line. The cf CLI also includes commands to return the value of the SSH access setting. See the [Accessing Apps with Diego SSH](./ssh-apps.html) topic to use and configure SSH at both the application level and the space level.
+Space managers and space developers can configure SSH access from the command line. The cf CLI also includes commands to return the value of the SSH access setting. See the [Accessing Apps with Diego SSH](./ssh-apps.html) topic to use and configure SSH at both the application level and the space level.
 
 ## <a id="platform-ssh-config"></a> Configuring SSH Access for <%= vars.product_full %>
 <%= vars.platform_ssh_configuration %>

--- a/deploy-apps/ssh-apps.html.md.erb
+++ b/deploy-apps/ssh-apps.html.md.erb
@@ -48,7 +48,7 @@ Under the hood, the cf CLI looks up the `app_ssh_oauth_client` identifier in the
 
 A cloud operator can deploy <%=vars.product_full%> to either allow or prohibit Application SSH across the entire deployment.
 
-Within a deployment that permits SSH access to applications, developers can enable or disable SSH access to individual applications. Space administrators can blanket allow or disallow SSH access to all apps running within a space.
+Within a deployment that permits SSH access to applications, space developers can enable or disable SSH access to individual applications. Space managers can blanket allow or disallow SSH access to all apps running within a space.
 
 ### <a id="configure-ssh-access-apps"></a>Configuring SSH Access at the Application Level
 [cf enable-ssh](http://cli.cloudfoundry.org/en-US/cf/enable-ssh.html) enables SSH access to all instances of an app:


### PR DESCRIPTION
The current description of the roles in these docs don't match the names
of the roles that are set within CF. `cf space-users` returns "SPACE
MANAGER", "SPACE DEVELOPER" and "SPACE AUDITOR".

This updates the docs to use these names, which should make things
clearer.