### PR TITLE
Add client library list for the CAPI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ docs-dev-guide/deploy-apps subdirectory:
 Develop and Manage Applications
 Develop and run applications in the cloud.
 
+docs-dev-guide/capi subdirectory:
+Manage resources via the Cloud Foundry API
+
 docs-dev-guide/services subdirectory:
 Custom Services
 Create and publish free or metered services for Cloud Foundry apps.
+
 
 This repo used to contain the subdirectory docs-dev-guide/cf-cli, documenting the Cloud Foundry Command Line Interface (cf CLI). The content from this subdirectory has been moved to its own repo, [docs-cf-cli](http://github.com/cloudfoundry/docs-cf-cli).
 

--- a/capi/client-libraries.html.md.erb
+++ b/capi/client-libraries.html.md.erb
@@ -1,0 +1,31 @@
+---
+title: Cloud Controller API Client Libraries
+owner: CAPI
+---
+
+<strong><%= modified_date %></strong>
+
+The CAPI API is the entry point for most operations within the Cloud Foundry
+platform. It can be used to mananage Organizations, Spaces and Applications, as
+well as user roles and permissions withing those. It is also used to manage all
+the Services provided by the platform, including provisioning, creating and
+binding them to applications.
+
+While one can develop programs that consume the CAPI API by talking to it
+directly using the API documentation, it is sometimes simpler to use an
+existing client library.
+
+Currently the following API Clients are *supported*:
+
+* Java: https://github.com/cloudfoundry/cf-java-client
+* Scripting (via the CF CLI): http://cli.cloudfoundry.org/en-US/cf/curl.html
+
+The following clients are *experimental* and a work in progress:
+
+* Golang: https://godoc.org/github.com/cloudfoundry/cli/api/cloudcontroller
+
+The following clients are unofficial and may supported by third-parties:
+
+* Golang: https://github.com/guidowb/cf-go-client
+* Golang: https://github.com/cloudfoundry-community/go-cfclient
+* Node.js: https://github.com/prosociallearnEU/cf-nodejs-client


### PR DESCRIPTION
Related to cloudfoundry/api-docs#3