### PR TITLE
Fix ssh environment `source` command example

### DIFF
--- a/deploy-apps/ssh-apps.html.md.erb
+++ b/deploy-apps/ssh-apps.html.md.erb
@@ -124,7 +124,7 @@ Before running commands below, verify that the contents of the files in both the
 If the `profile` and `.profile.d` scripts would alter your instance in undesirable ways, only run the commands in them that you need for environmental setup.
 
 <pre class="terminal">
-source /home/vcap/app/.profile.d/*.sh
+for f in /home/vcap/app/.profile.d/*.sh; do source "$f"; done
 source /home/vcap/app/.profile
 </pre>
 


### PR DESCRIPTION
`source` only takes a single file argument, meaning if there is more than one file returned by the shell glob it will be ignored and not sourced. There are shorter versions of the fixed command, but they are shell specific whereas this is portable across shells.