### PR TITLE
Make punctuation in tables consistent

### DIFF
--- a/deploy-apps/environment-variable.html.md.erb
+++ b/deploy-apps/environment-variable.html.md.erb
@@ -330,19 +330,19 @@ The key for each service in the JSON document is the same as the value of the
   </tr>
   <tr>
     <td><code>name</code></td>
-    <td>The name assigned to the service instance by the user</td>
+    <td>The name assigned to the service instance by the user.</td>
   </tr>
   <tr>
     <td><code>label</code></td>
-    <td>The name of the service offering</td>
+    <td>The name of the service offering.</td>
   </tr>
   <tr>
     <td><code>tags</code></td>
-    <td>An array of strings an app can use to identify a service instance</td>
+    <td>An array of strings an app can use to identify a service instance.</td>
   </tr>
   <tr>
     <td><code>plan</code></td>
-    <td>The service plan selected when the service instance was created</td>
+    <td>The service plan selected when the service instance was created.</td>
   </tr>
   <tr>
     <td><code>credentials</code></td>
@@ -415,19 +415,19 @@ The table below lists the commands for environment variable groups.
   </tr>
   <tr>
     <td><code>running-environment-variable-group</code> or <code>revg</code></td>
-    <td>Retrieves the contents of the running environment variable group</td>
+    <td>Retrieves the contents of the running environment variable group.</td>
   </tr>
   <tr>
     <td><code>staging-environment-variable-group</code> or <code>sevg</code></td>
-    <td>Retrieves the contents of the staging environment variable group</td>
+    <td>Retrieves the contents of the staging environment variable group.</td>
   </tr>
   <tr>
     <td><code>set-staging-environment-variable-group</code> or <code>ssevg</code></td>
-    <td>Passes parameters as JSON to create a staging environment variable group</td>
+    <td>Passes parameters as JSON to create a staging environment variable group.</td>
   </tr>
   <tr>
     <td><code>set-running-environment-variable-group</code> or <code>srevg</code></td>
-    <td>Passes parameters as JSON to create a running environment variable group</td>
+    <td>Passes parameters as JSON to create a running environment variable group.</td>
   </tr>
  </table>
 


### PR DESCRIPTION
The Cloud Foundry Environment Variables section has three tables. In the first table—VCAP_APPLICATION—every sentence/sentence fragment ends with a period. In the second table—VCAP_SERVICES—periods are used inconsistently (only one fragment out of five ends with a period). The third table—Environment Variable Groups—doesn’t have any ending punctuation marks.

To make the punctuation consistent, I added periods to every sentence fragment in the second and third tables.
