### PR TITLE
Usability improvements to accessing services via SSH

### DIFF
--- a/deploy-apps/ssh-services.html.md.erb
+++ b/deploy-apps/ssh-services.html.md.erb
@@ -48,14 +48,14 @@ Getting key EXTERNAL-ACCESS-KEY for service instance MY-DB as user<span>@</span>
 ##<a id="ssh-tunnel"></a>Configure Your SSH Tunnel
 
 Configure an SSH tunnel to your service instance using [cf ssh](http://cli.cloudfoundry.org/en-US/cf/ssh.html). Tailor the example command below with information from your service key.
-<pre class="terminal">$ cf ssh -N -L 63306:<%= vars.ssh_service_host %>:3306 YOUR-HOST-APP</pre>
+<pre class="terminal">$ cf ssh -L 63306:<%= vars.ssh_service_host %>:3306 YOUR-HOST-APP</pre>
 
   * Use any available local port for port forwarding. For example, `63306`.
   * Replace `<%= vars.ssh_service_host %>` with the address provided under `hostname` in the service key retrieved above.
   * Replace `3306` with the port provided under `port` above.
   * Replace `YOUR-HOST-APP` with the name of your host app.
 
-The `cf ssh` command runs in the foreground and does not return a value. After you enter the command, open another terminal window and perform the steps below in [Access Your Service Instance](#access-service).
+After you enter the command, open another terminal window and perform the steps below in [Access Your Service Instance](#access-service).
 
 ##<a id="access-service"></a>Access Your Service Instance##
 To establish direct command-line access to your service instance, use the relevant command line tool for that service. This example uses the MySQL command line client to access the <%= vars.ssh_service %> service instance.

--- a/deploy-apps/ssh-services.html.md.erb
+++ b/deploy-apps/ssh-services.html.md.erb
@@ -48,12 +48,12 @@ Getting key EXTERNAL-ACCESS-KEY for service instance MY-DB as user<span>@</span>
 ##<a id="ssh-tunnel"></a>Configure Your SSH Tunnel
 
 Configure an SSH tunnel to your service instance using [cf ssh](http://cli.cloudfoundry.org/en-US/cf/ssh.html). Tailor the example command below with information from your service key.
-<pre class="terminal">$ cf ssh -N -L 63306:<%= vars.ssh_service_host %>:3306 spring-music</pre>
+<pre class="terminal">$ cf ssh -N -L 63306:<%= vars.ssh_service_host %>:3306 YOUR-HOST-APP</pre>
 
   * Use any available local port for port forwarding. For example, `63306`.
   * Replace `<%= vars.ssh_service_host %>` with the address provided under `hostname` in the service key retrieved above.
   * Replace `3306` with the port provided under `port` above.
-  * Replace `spring-music` with the name of your host app.
+  * Replace `YOUR-HOST-APP` with the name of your host app.
 
 The `cf ssh` command runs in the foreground and does not return a value. After you enter the command, open another terminal window and perform the steps below in [Access Your Service Instance](#access-service).
 


### PR DESCRIPTION
We conducted some usability testing with the scenario of having people try to import data into a postgres database by following the Accessing Services with SSH guide.

We found two things that slowed people down:

### Copying the examples and editing them. 

There are quite a few things we noticed that people spent time on here, copying and pasting hostnames, database names and credentials out of JSON for example, although I haven't addressed that. The thing I chose to address here was that they weren't able to see what to substitute for `spring-music` without reading further on in the docs. 

People don't read on in the docs, they prefer to finish each step before they move forward, so it doesn't matter if you give them the answer on the following line; they probably won't read it. 

### Thinking the ssh command was hanging

That `-N` flag in `cf ssh` threw everyone for at least some length of time, because you couldn't tell if had worked, so people assumed it was hanging somehow.

Again, people weren't helped by the sentence that followed, explaining what happened because they like to read sequentially. Mostly we gave up after a few minutes and told them what was happening.