### PR TITLE
removed unsupported flag

### DIFF
--- a/deploy-apps/ssh-apps.html.md.erb
+++ b/deploy-apps/ssh-apps.html.md.erb
@@ -107,7 +107,7 @@ $ cf ssh MY-AWESOME-APP -L [LOCAL-NETWORK-INTERFACE:]LOCAL-PORT:REMOTE-HOST-NAME
 
 * The `-N` flag skips returning a command prompt on the remote machine. This sets up local port forwarding if you do not need to execute commands on the host VM.
 
-* The `-t`, `-tt`, and `-T` flags let you run an SSH session in pseudo-tty mode rather than generate terminal line output.
+* The `--request-pseudo-tty` and `--force-pseudo-tty ` flags let you run an SSH session in pseudo-tty mode rather than generate terminal line output.
 
 ## <a id="ssh-env"></a>SSH Session Environment
 


### PR DESCRIPTION
There is no '-tt'. Also, `-T` is to disable pseudo-tty allocation, so does not belong in a list of flags to "let you run an SSH session in pseudo-tty".
http://cli.cloudfoundry.org/en-US/cf/ssh.html