### PR TITLE
Update environment-variable.html.md.erb

### DIFF
--- a/deploy-apps/environment-variable.html.md.erb
+++ b/deploy-apps/environment-variable.html.md.erb
@@ -244,7 +244,7 @@ Example: `CF_INSTANCE_IP=1.2.3.4`
 ### <a id='CF-INSTANCE-INTERNAL-IP'></a>CF\_INSTANCE\_INTERNAL_IP ###
 The internal IP address of the container running the app instance.
 
-Example: `CF_INSTANCE_INTERNAL_IP=1.2.3.4`
+Example: `CF_INSTANCE_INTERNAL_IP=5.6.7.8`
 
 ### <a id='CF-INSTANCE-PORT'></a>CF\_INSTANCE\_PORT ###
 


### PR DESCRIPTION
Since CF_INSTANCE_IP and CF_INSTANCE_INTERNAL_IP will always be different (AFAIK), I believe it improves comprehension to make the example IP addresses different (a customer found current usage of 1.2.3.4 for both addresses potentially confusing).