### PR TITLE
Clarify $PORT most often defaults to 8080 in diego

### DIFF
--- a/deploy-apps/environment-variable.html.md.erb
+++ b/deploy-apps/environment-variable.html.md.erb
@@ -261,7 +261,7 @@ Not all of the internal ports are necessarily available for the application to
 bind to, as some of them may be used by system-provided services that also run
 inside the container. These internal and external values may differ.
 
-Example: `CF_INSTANCE_PORTS=[{external:61045,internal:5678},{external:61046,internal:2222}]`
+Example: `CF_INSTANCE_PORTS=[{external:61045,internal:8080},{external:61046,internal:2222}]`
 
 ### <a id='DATABASE-URL'></a>DATABASE\_URL ###
 
@@ -330,7 +330,7 @@ The Cloud Foundry runtime allocates a port dynamically for each instance of the
 application, so code that obtains or uses the app port should refer to
 it using the `PORT` environment variable.
 
-Example: `PORT=61857`
+Example: `PORT=8080`
 
 ### <a id='PWD'></a>PWD ###
 Identifies the present working directory, where the buildpack that processed


### PR DESCRIPTION
https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html#http-vs-tcp-routes mentions 

`Applications should listen to the localhost port defined by the $PORT environment variable, which is 8080 on Diego.`

The descriptions and examples were still mentioning arbitrary dynamic ports that used to be generated DEAs.

With this PR, examples 8080 for internal ports. This allows app developers to predict internal ports, and specify them in container policies, see https://github.com/cloudfoundry/cf-networking-release/pull/24 

Also, I understand Diego does not yet support multiple app binding ports, whereas the example at https://github.com/cloudfoundry/docs-dev-guide/blob/31117ab9c3c24ddb9f4eca090d5566e70ae819d6/deploy-apps/environment-variable.html.md.erb#L264 specify more than one internal port.

