### PR TITLE
Restart of app required after enabling SSH access

### DIFF
--- a/deploy-apps/ssh-apps.html.md.erb
+++ b/deploy-apps/ssh-apps.html.md.erb
@@ -50,6 +50,8 @@ A cloud operator can deploy <%=vars.product_full%> to either allow or prohibit A
 
 Within a deployment that permits SSH access to applications, Space Developers can enable or disable SSH access to individual applications, and Space Managers can enable or disable SSH access to all apps running within a space.
 
+You need to restart your application after enabling SSH access.
+
 ### <a id="configure-ssh-access-apps"></a>Configuring SSH Access at the Application Level
 [cf enable-ssh](http://cli.cloudfoundry.org/en-US/cf/enable-ssh.html) enables SSH access to all instances of an app:
 <pre class="terminal">


### PR DESCRIPTION
If an app is created without ssh access enabled, you need to restart it after enabling ssh before you can actually ssh into it. Otherwise the ssh route doesn't exist and the ssh deamon is not started in the container.

This happens e.g. on landscapes where the ssh access is disabled by default for all apps ([default_app_ssh_access](http://bosh.io/jobs/cloud_controller_ng?source=github.com/cloudfoundry/cf-release&version=281#p=cc.default_app_ssh_access): false).

Related PR for cf cli: https://github.com/cloudfoundry/cli/issues/1282