### PR TITLE
Stating that inheritance is deprecated

### DIFF
--- a/deploy-apps/manifest.html.md.erb
+++ b/deploy-apps/manifest.html.md.erb
@@ -683,3 +683,11 @@ applications
   - route: www.example.com/foo 
   - route: tcp.example.com:1234
 </pre>
+
+This app manifest feature has been deprecated, and a replacement option is under consideration.
+
+### <a id='inheritance-deprecated'></a> Inheritance is deprecated
+
+With inheritance, child manifests would inherit configurations from a parent manifest, and they could use inherited configurations as-is, extend them, or override them.
+The CF CLI team is considering replacing Inheritance with Value Substitution, similar to the approach that BOSH and Concourse use. 
+If you have feedback on this change, contact the team on the #cli channel on the Cloud Foundry Slack.


### PR DESCRIPTION
We initially published the app manifest deprecation changes without a reference to inheritance, because the features to replace inheritance haven't been delivered yet. Now we're thinking it would be better to state this change and invite people to provide feedback while we work on the replacement.