### PR TITLE
Note for inheritance section about deprecation

### DIFF
--- a/deploy-apps/manifest.html.md.erb
+++ b/deploy-apps/manifest.html.md.erb
@@ -541,6 +541,8 @@ This manifest pushes two apps, smallapp and bigapp, with the staticfile buildpac
 
 ##<a id='multi-manifests'></a>Multiple Manifests with Inheritance ##
 
+**IMPORTANT** Inheritance is deprecated. See the section below on app manifest deprecations for more information.
+
 A single manifest can describe multiple applications. Another powerful technique is to create multiple manifests with inheritance. Here, manifests have parent-child relationships such that children inherit descriptions from a parent. Children can use inherited descriptions as-is, extend them, or override them.
 
 Content in the child manifest overrides content in the parent manifest, if the two conflict.


### PR DESCRIPTION
@cshollingsworth Please merge this change as a temporary solution until we have implemented an alternative to inheritance. At that point, I expect we'll remove the inheritance section from this page and mention it only with deprecated app manifest features. 