### PR TITLE
Add missing * in YAML anchor example

### DIFF
--- a/deploy-apps/manifest.html.md.erb
+++ b/deploy-apps/manifest.html.md.erb
@@ -532,9 +532,9 @@ defaults: &amp;defaults
 
 applications:
 - name: bigapp
-  &lt;&lt;: defaults
+  &lt;&lt;: *defaults
 - name: smallapp
-  &lt;&lt;: defaults
+  &lt;&lt;: *defaults
   memory: 256M
 </pre>
 


### PR DESCRIPTION
The example of YAML anchors is invalid because it is missing a `*`. 
You can see this if you try to `cf push` the example manifest; it fails with:
```
FAILED
Error reading manifest file:
yaml: map merge requires map or sequence of maps as the value
```
