### PR TITLE
Configuration parameters visibility for shared service instances

### DIFF
--- a/services/sharing-instances.html.md.erb
+++ b/services/sharing-instances.html.md.erb
@@ -42,6 +42,10 @@ in which they have the SpaceDeveloper role.
 * Developers who have a service instance shared with them can only bind and unbind to that 
 service instance. They cannot update, rename, or delete it.
 
+* Developers who have a service instance shared with them will be able to see the values of
+any configuration parameters that were used to configure the service instance when it was
+provisioned or updated.
+
 ## <a id="enabling"></a> Enabling Service Instance Sharing in Cloud Foundry
 
 To enable service instance sharing, an administrator must enable the `service_instance_sharing` flag:


### PR DESCRIPTION
Add a bullet point explaining that configuration parameters used for shared service instances will be visible.