### PR TITLE
Remove v3-share-service and v3-share-service commands

### DIFF
--- a/v3-commands.html.md.erb
+++ b/v3-commands.html.md.erb
@@ -91,14 +91,6 @@ Consult the following table for a description of the experimental commands.
 <td>Changes type of health check performed on an app's process</td>
 </tr>
 <tr>
-<td><code>v3-share-service</code></td>
-<td>Shares a service instance to another space across orgs. See <a href="./services/sharing-instances.html"> Sharing Service Instances</a>.</td>
-</tr>
-<tr>
-<td><code>v3-unshare-service</code></td>
-<td>Unshares a service instance that has been shared to another space across orgs. See <a href="./services/sharing-instances.html"> Sharing Service Instances</a>.</td>
-</tr>
-<tr>
 <td><code>v3-stage</code></td>
 <td>Creates a new droplet for an app</td>
 </tr>


### PR DESCRIPTION
These commands no longer have the v3-prefix, so we should remove these from this doc.

cc @jbpivotal @samze