### PR TITLE
Include star in YAML alias example

### DIFF
--- a/deploy-apps/manifest.html.md.erb
+++ b/deploy-apps/manifest.html.md.erb
@@ -648,9 +648,9 @@ defaults: &amp;defaults
 
 applications:
 - name: bigapp
-  &lt;&lt;: defaults
+  &lt;&lt;: *defaults
 - name: smallapp
-  &lt;&lt;: defaults
+  &lt;&lt;: *defaults
   memory: 256M
 </pre>
 


### PR DESCRIPTION
The YAML anchor/alias example wasn't quite right without these stars.