### PR TITLE
fix the Cloud Controller's property name

### DIFF
--- a/deploy-apps/manifest.html.md.erb
+++ b/deploy-apps/manifest.html.md.erb
@@ -390,9 +390,9 @@ For example:
   timeout: 80
 </pre>
 
-You can increase the timeout length for very large apps that require more time to start. The `timeout` attribute defaults to 60, but you can set it to any value up to the Cloud Controller's `maximum_health_check_timeout` property.
+You can increase the timeout length for very large apps that require more time to start. The `timeout` attribute defaults to 60, but you can set it to any value up to the Cloud Controller's `health_check_timeout` property.
 
-`maximum_health_check_timeout` defaults to 180, but your Cloud Foundry operator can set to any value.
+`health_check_timeout` defaults to 180, but your Cloud Foundry operator can set to any value.
 
 The command line option that overrides the timeout attribute is `-t`.
 


### PR DESCRIPTION
`maximum_health_check_timeout` -> `health_check_timeout`