### PR TITLE
add ldap bind-service example

### DIFF
--- a/services/using-vol-services.html.md.erb
+++ b/services/using-vol-services.html.md.erb
@@ -44,6 +44,8 @@ To use a volume service deployed by <%= vars.admin %>, you must first create an 
     The following example shows binding `my-app` to the `nfs_service_instance` and specifying a read-only volume to be mounted to `/var/volume1`,
     passing an in-line JSON string:
     <pre class="terminal">$ cf bind-service my-app nfs\_service\_instance -c '{"uid":"1000","gid":"1000","mount":"/var/volume1","readonly":true}'</pre>
+    or an example using a LDAP user's credentials:
+    <pre class="terminal">$ cf bind-service my-app nfs\_service\_instance -c '{"username":"user1000","password":"secret","mount":"/var/volume1","readonly":true}'</pre>
 
 1. Run `cf restage YOUR-APP` to complete the service binding by restaging your app. Replace `YOUR-APP` with the name of your app.
   <pre class="terminal">$ cf restage my-app</pre>


### PR DESCRIPTION
Add example of cf bind-service with LDAP user credentials as there is no client document on how to do that.
https://github.com/cloudfoundry/nfs-volume-release/blob/master/USING_LDAP.md#testing