### PR TITLE
1.15

### DIFF
--- a/deploy-apps/_c2c_oss_enable.html.md.erb
+++ b/deploy-apps/_c2c_oss_enable.html.md.erb
@@ -381,7 +381,7 @@ Enter the following command to deploy CF.
 Enter the following command to deploy Diego.
 <pre class="terminal">$ bosh deploy</pre>
 </li>
-<li>(Optional) Try the <a href="https://github.com/cloudfoundry-incubator/cf-networking-release/tree/develop/src/example-apps/cats-and-dogs">Cats and Dogs</a> example in the Container-to-Container Networking Release repository. In this tutorial, you deploy two apps and create a Container-to-Container Networking policy that allows them to communicate directly with each other. 
+<li>To see how container networking works with and without service discovery, see <a href="https://github.com/cloudfoundry/cf-networking-examples/blob/master/docs/c2c-with-service-discovery.md">Cats and Dogs with Service Discovery</a> in GitHub. In this tutorial, you deploy two apps and create a Container-to-Container Networking policy that allows them to communicate directly with each other. 
  </li>
 </ol>
 
@@ -406,6 +406,6 @@ If your CF deployment runs on BOSH-Lite, follow these steps to enable Container-
   <pre class="terminal">$ git clone https<span>:</span>//github.com/cloudfoundry/diego-release<br>$ git clone https<span>:</span>//github.com/cloudfoundry/cf-release<br>$ git clone https<span>:</span>//github.com/cloudfoundry-incubator/cf-networking-release</pre></li>
   <li>To enable Container-to-Container Networking on BOSH-Lite, navigate to the `cf-networking-release` directory and run the deploy script:<br>
   <pre class="terminal">$ cd ~/workspace/cf-networking-release<br>$ ./scripts/deploy-to-bosh-lite</pre></li>
- <li>(Optional) Try the <a href="https://github.com/cloudfoundry-incubator/cf-networking-release/tree/develop/src/example-apps/cats-and-dogs">Cats and Dogs</a> example in the Container-to-Container Networking Release repository. In this tutorial, you deploy two apps and create a Container-to-Container Networking policy that allows them to communicate directly with each other. 
+ <li>(Optional) To see how container networking works with and without service discovery, see <a href="https://github.com/cloudfoundry/cf-networking-examples/blob/master/docs/c2c-with-service-discovery.md">Cats and Dogs with Service Discovery</a> in GitHub. In this tutorial, you deploy two apps and create a Container-to-Container Networking policy that allows them to communicate directly with each other. 
  </li>
 </ol>

--- a/deploy-apps/cf-networking.html.md.erb
+++ b/deploy-apps/cf-networking.html.md.erb
@@ -59,7 +59,7 @@ This topic describes how to configure the Container-to-Container Networking feat
 
 This section describes how to create and modify Container-to-Container Networking policies using the Cloud Foundry Command Line Interface (cf CLI).
 The cf CLI only supports configuring policies for apps within the same space. 
-To configure policies for apps in different orgs and spaces, use the [Policy Server External API](https://github.com/cloudfoundry/cf-networking-release/blob/master/docs/API.md).
+To configure policies for apps in different orgs and spaces, use the [Policy Server External API](https://github.com/cloudfoundry/cf-networking-release/blob/v1.10.x/docs/API.md).
 
 <p class='note'><strong>Note:</strong> With the NSX-T integration, container networking policies and ASGs continue to work as normal. Advanced ASG logging is not supported with NSX-T.</p>
 

--- a/deploy-apps/environment-variable.html.md.erb
+++ b/deploy-apps/environment-variable.html.md.erb
@@ -265,11 +265,9 @@ Example: `CF_INSTANCE_PORTS=[{external:61045,internal:8080},{external:61046,inte
 
 ### <a id='DATABASE-URL'></a>DATABASE\_URL ###
 
-At runtime, CF creates a `DATABASE_URL` environment variable
-for every app based on the [VCAP_SERVICES](#VCAP-SERVICES) environment variable.
+For apps bound to certain services that use a database, CF creates a `DATABASE_URL` environment variable based on the [VCAP_SERVICES](#VCAP-SERVICES) environment variable at runtime.
 
-CF uses the structure of the `VCAP_SERVICES` environment
-variable to populate `DATABASE_URL`.
+CF uses the structure of the `VCAP_SERVICES` environment variable to populate `DATABASE_URL`.
 CF recognizes any service containing a JSON object with the following form as a candidate for `DATABASE_URL` and uses the first candidate it finds.
 
     {

--- a/deploy-apps/healthchecks.html.md.erb
+++ b/deploy-apps/healthchecks.html.md.erb
@@ -47,6 +47,8 @@ Replace the placeholders in the example command above as follows:
 
 <p class="note"><strong>Note</strong>: You can change the health check configuration of a deployed app with <code>cf set-health-check</code>, but you must restart the app for the changes to take effect.</p>
 
+<p class="note"><strong>Note</strong>: You can also use the <code>v3-set-health-check</code> CLI command to change the individual health check invocation timeout for an app. This option also requires restarting the app. See the <a href="https://docs.cloudfoundry.org/cf-cli/cf-help.html#apps-(experimental)">Cloud Foundry CLI Reference Guide</a> for more information.</p>
+
 ##<a id='understand-healthchecks'></a> Understand Health Checks
 
 ###<a id='healthcheck-lifecycle'></a> Health Check Lifecycle

--- a/deploy-apps/instance-identity.html.md.erb
+++ b/deploy-apps/instance-identity.html.md.erb
@@ -11,7 +11,7 @@ The environment variable `CF_INSTANCE_CERT` contains the absolute path of the ce
 
 - The `Common Name` property is set to the instance GUID.
 - The certificate contains an IP SAN set to the container IP address for the given app instance.
-- For Cloud Foundry apps, the `Organizational Unit` property is set to the string `app:APP-GUID`, where `APP-GUID` is the application GUID assigned by Cloud Controller.
+- For Cloud Foundry apps, the `Organizational Unit` property in the certificate's Subject Distinguished Name contains the values `organization:org-guid`, `space:space-guid`, and `app:app-guid`. `org-guid`, `space-guid`, and `app-guid` are respectively set to the GUIDs for the organization, space, and application as assigned by Cloud Controller.
 
 By default, the certificate is valid for 24 hours after the container is created. To change the validity period, set the `diego.executor.instance_identity_validity_period_in_hours` BOSH property. The smallest allowed validity duration is 1 hour.
 

--- a/deploy-apps/instance-identity.html.md.erb
+++ b/deploy-apps/instance-identity.html.md.erb
@@ -5,16 +5,20 @@ owner: Diego
 
 <strong><%= modified_date %></strong>
 
-This topic describes how to use the Instance Identity system provided by Cloud Foundry. The Instance Identity system provides each application with a PEM-encoded [X.509](https://tools.ietf.org/html/rfc5280) certificate and [PKCS#1](https://tools.ietf.org/html/rfc3447) RSA private key.
+This topic describes enabling the Instance Identity system for your Cloud Foundry (CF) deployment.  The Instance Identity system provides each app instance with a unique PEM-encoded [X.509](https://tools.ietf.org/html/rfc5280) certificate and [PKCS#1](https://tools.ietf.org/html/rfc3447) RSA private key pair that encodes its identity in the CF deployment.
 
-The environment variable `CF_INSTANCE_CERT` contains the absolute path of the certificate. The environment variable `CF_INSTANCE_KEY` contains the private key files. The provided certificate has the following properties:
+The environment variable `CF_INSTANCE_CERT` contains the absolute path to the certificate. The environment variable `CF_INSTANCE_KEY` contains the absolute path to the key file. The provided certificate has the following properties:
 
-- The `Common Name` property is set to the instance GUID.
+- The `Common Name` property is set to the instance GUID for the given app instance.
 - The certificate contains an IP SAN set to the container IP address for the given app instance.
-- For Cloud Foundry apps, the `Organizational Unit` property in the certificate's Subject Distinguished Name contains the values `organization:org-guid`, `space:space-guid`, and `app:app-guid`. `org-guid`, `space-guid`, and `app-guid` are respectively set to the GUIDs for the organization, space, and application as assigned by Cloud Controller.
+- The certificate contains a DNS SAN set to the instance GUID for the given app instance.
+- The `Organizational Unit` property in the certificate's Subject Distinguished Name contains the values `organization:ORG-GUID`, `space:SPACE-GUID`, and `app:APP-GUID`. The `ORG-GUID`, `SPACE-GUID`, and `APP-GUID` are set to the GUIDs for the organization, space, and app as assigned by Cloud Controller.
 
-By default, the certificate is valid for 24 hours after the container is created. To change the validity period, set the `diego.executor.instance_identity_validity_period_in_hours` BOSH property. The smallest allowed validity duration is 1 hour.
+By default, the certificate is valid for 24 hours after the container is created. The CF platform operator can decrease this duration to as little as 1 hour by setting the `diego.executor.instance_identity_validity_period_in_hours` BOSH property.
 
-The Diego Cell rep will supply a new certificate-key pair to the container before the end of the validity period. The new pair of files replaces the existing pair at the same path location, with each file replaced atomically.
+The Diego cell rep supplies a new certificate and private key pair to the app instance before the end of the validity period. The new pair of files replaces the existing pair at the same path locations, with each file replaced atomically. 
+
+* If the validity period exceeds 4 hours, the pair regenerates between 1 hour and 20 minutes before the end of the validity period. 
+* If the validity period is less than or equal to 4 hours, the pair regenerates between 1/4 and 1/12 of the time to the end of the period.
 
 For more information about enabling and configuring the Instance Identity system in Cloud Foundry, see [Enabling Instance Identity](../../adminguide/instance-identity.html).

--- a/deploy-apps/manifest.html.md.erb
+++ b/deploy-apps/manifest.html.md.erb
@@ -388,13 +388,13 @@ For example:
   ...
   timeout: 80
 </pre>
-
+<% if vars.product_name == 'CF' %>
 You can increase the timeout length for very large apps that require more time to start. The `timeout` attribute defaults to 60, but you can set it to any value up to the Cloud Controller's `maximum_health_check_timeout` property.
 
 `maximum_health_check_timeout` defaults to 180, but your Cloud Foundry operator can set to any value.
 
 The command line option that overrides the timeout attribute is `-t`.
-
+<% end %>
 ##<a id='env-block'></a>Environment Variables ###
 
 The `env` block consists of a heading, then one or more environment variable/value pairs.

--- a/deploy-apps/manifest.html.md.erb
+++ b/deploy-apps/manifest.html.md.erb
@@ -210,8 +210,7 @@ The command line option `--docker-image` or `-o` overrides `docker.image`.  The 
 
 The manifest attribute `docker.username` is optional.  If it is used, then the password must be provided in the environment variable `CF_DOCKER_PASSWORD`.  Additionally, if a Docker username is specified, then a Docker image must also be specified.
 
-#### Manifest Attributes
-The `docker` attribute cannot be used in conjunction with the following attributes: `buildpack` and `path`. An error will result.
+<p class="note"><strong>Note</strong>: Using the <code>docker</code> attribute in conjunction with the <code>buildpack</code> or <code>path</code> attributes will result in an error.</p>
 
 ###<a id='health-check-http-endpoint'></a>health-check-http-endpoint ###
 
@@ -527,15 +526,15 @@ You can declare shared configuration using a YAML anchor, which the manifest ref
 <pre>
 ---
 defaults: &amp;defaults
-  buildpack: staticfile_buildpack
-  memory: 1G
+  buildpack: staticfile_buildpack
+  memory: 1G
 
 applications:
 - name: bigapp
-  &lt;&lt;: *defaults
+  &lt;&lt;: *defaults
 - name: smallapp
-  &lt;&lt;: *defaults
-  memory: 256M
+  &lt;&lt;: *defaults
+  memory: 256M
 </pre>
 
 This manifest pushes two apps, smallapp and bigapp, with the staticfile buildpack but with 256M memory for smallapp and 1G for bigapp.
@@ -643,15 +642,15 @@ The following example illustrates how to declare shared configuration using a YA
 <pre>
 ---
 defaults: &amp;defaults
-  buildpack: staticfile_buildpack
-  memory: 1G
+  buildpack: staticfile_buildpack
+  memory: 1G
 
 applications:
 - name: bigapp
-  &lt;&lt;: *defaults
+  &lt;&lt;: *defaults
 - name: smallapp
-  &lt;&lt;: *defaults
-  memory: 256M
+  &lt;&lt;: *defaults
+  memory: 256M
 </pre>
 
 When pushing the app, make explicit the attributes in each app’s declaration. To do this, assign the anchors and include the app-level attributes with YAML aliases in each app declaration.
@@ -664,9 +663,9 @@ Previously, you could specify routes by listing them all at once using the `rout
 ---
 applications
 - name: webapp
-  host: www
-  domains:
-  - example.com
+  host: www
+  domains:
+  - example.com
   - example.io
 </pre>
 
@@ -685,13 +684,15 @@ Now you can only specify routes by using the `routes` attribute:
 ---
 applications
 - name: webapp
-  routes:
-  - route: www.example.com/foo 
-  - route: tcp.example.com:1234
+  routes:
+  - route: www.example.com/foo 
+  - route: tcp.example.com:1234
 </pre>
 
 This app manifest feature has been deprecated, and a replacement option is under consideration.
 
-### <a id='inheritance-deprecated'></a> Inheritance Is Deprecated
+### <a id='inheritance-deprecated'></a> Inheritance
 
-With inheritance, child manifests inherited configurations from a parent manifest, and the child manifests could use inherited configurations as provided, extend them, or override them. This feature has been deprecated.
+This feature has been deprecated.
+
+With inheritance, child manifests inherited configurations from a parent manifest, and the child manifests could use inherited configurations as provided, extend them, or override them. 

--- a/deploy-apps/routes-domains.html.md.erb
+++ b/deploy-apps/routes-domains.html.md.erb
@@ -505,6 +505,8 @@ The domain `foo.myapp.<%=vars.app_domain%>` is the child subdomain of `myapp.<%=
 
 To create customized access to your apps, you can map specific or wildcard custom domains to <%=vars.product_short%> by using your DNS provider.
 
+<%=vars.domains_on_hosted%>
+
 #### <a id='subdomain-dns'></a>Mapping Domains to Your Custom Domain ####
 
 To associate a registered domain name with a domain on <%=vars.product_short%>, configure a CNAME record with your DNS provider, pointing at any shared domain offered in <%=vars.product_short%>.

--- a/deploy-apps/routes-domains.html.md.erb
+++ b/deploy-apps/routes-domains.html.md.erb
@@ -328,6 +328,44 @@ Developers can map a route to their app with a manifest by editing the `route` a
 
 See the [Routing Conflict](./troubleshoot-app-health.html#routing-conflict) section of the Troubleshooting Application Deployment and Health topic for more information about troubleshooting this problem.
 
+#### <a id='map-multiple-routes'></a>Map Multiple Routes to One App ####
+
+You can have multiple routes to an app, but those routes cannot have different context paths.
+
+The following routes are valid for a single app:
+
+<table>
+  <tr>
+    <th>Route 1</th>
+    <th>Route 2</th>
+  </tr>
+  <tr>
+    <td><code>myapp.example.com</code></td>
+    <td><code>myapp.apps.cf.example.com</code></td>
+  </tr>
+  <tr>
+    <td><code>myapp.example.com/foo</code></td>
+    <td><code>myapp.apps.cf.example.com/foo</code></td>
+  </tr>
+</table>
+
+The following routes are **not** valid for a single app:
+
+<table>
+  <tr>
+    <th>Route 1</th>
+    <th>Route 2</th>
+  </tr>
+  <tr>
+    <td><code>myapp.example.com/foo</code></td>
+    <td><code>myapp.apps.cf.example.com/bar</code></td>
+  </tr>
+  <tr>
+    <td><code>myapp.apps.cf.example.com/foo</code></td>
+    <td><code>myapp.example.com/bar</code></td>
+  </tr>
+</table>
+
 ### <a id='unmap-route'></a>Unmap a Route ###
 
 Developers can remove a route from an app using the `cf unmap-route` command. The route remains reserved for later use in the space where it was created until the route is deleted.

--- a/deploy-apps/routes-domains.html.md.erb
+++ b/deploy-apps/routes-domains.html.md.erb
@@ -505,8 +505,6 @@ The domain `foo.myapp.<%=vars.app_domain%>` is the child subdomain of `myapp.<%=
 
 To create customized access to your apps, you can map specific or wildcard custom domains to <%=vars.product_short%> by using your DNS provider.
 
-<%=vars.domains_on_hosted%>
-
 #### <a id='subdomain-dns'></a>Mapping Domains to Your Custom Domain ####
 
 To associate a registered domain name with a domain on <%=vars.product_short%>, configure a CNAME record with your DNS provider, pointing at any shared domain offered in <%=vars.product_short%>.

--- a/deploy-apps/streaming-logs.html.md.erb
+++ b/deploy-apps/streaming-logs.html.md.erb
@@ -215,10 +215,5 @@ If you are developing a client that displays a stream of Cloud Foundry logs to u
 
 * Batch the logs and display whatever logs you have in that timeframe sorted by timestamp. This technique is good for CLIs. 
 * For web clients you can use dynamic HTML to insert older logs into the sorting as they appear. This is nice because by the time a user grabs the content for a copy paste, the logs will likely be both complete and in order. 
-* Java app developers may want to convert stack traces into a single log entity. For more information, see [Multi-Line Stack Traces as a Single Log Entity](#multi-line-stack-traces).
-
-#### <a id=‘multi-line-stack-traces’></a> Multi-Line Stack Traces as a Single Log Entity
-
-To simplify log ordering for Java apps, use the [multi-line Java message workaround](https://github.com/cloudfoundry/loggregator-release/blob/develop/docs/java-multi-line-work-around.md) to convert your multi-line stack traces into a single log entity. 
-
-By modifying the Java log output, you can make your app reformat your stack trace messages so any newline characters are replaced with a token. Then, you can make your log parsing code replace that token with newline characters again to display the logs properly in Kibana.
+* Java app developers may want to convert stack traces into a single log entity. To simplify log ordering for Java apps, use the [multi-line Java message workaround](https://github.com/cloudfoundry/loggregator-release/blob/develop/docs/java-multi-line-work-around.md) to convert your multi-line stack traces into a single log entity. 
+<br><br>By modifying the Java log output, you can make your app reformat your stack trace messages so any newline characters are replaced with a token. Then, you can make your log parsing code replace that token with newline characters again to display the logs properly in Kibana.

--- a/deploy-apps/streaming-logs.html.md.erb
+++ b/deploy-apps/streaming-logs.html.md.erb
@@ -154,16 +154,9 @@ performance.
 
 ## <a id='container-metrics'></a> Including Container Metrics in Syslog Drains
 
-By default, app logs are included in syslog drains. To include container metrics in your syslog drain, `scalablesyslog.adapter.metrics_to_syslog_enabled` must be set to `true`&nbsp;. 
-
-<% if not vars.product_full == "Cloud Foundry" %>
-To set this property to `true`, select the **System Logging** pane in <%= vars.product_full%> (<%= vars.product_short%>) and enable the **Include container metrics in SysLog Drains** checkbox. In <%= vars.product_short %> <%= vars.current_major_version.to_f - 0.1 %>, this property is set to `true` by default.
-<% end %>
-
-Once `scalablesyslog.adapter.metrics_to_syslog_enabled` is set to `true`, run the following cf CLI command:
-
-`cf create-drain -metrics YOUR-APP-INSTANCE YOUR-SYSLOG-DRAIN SYSLOG-DRAIN-URL`
-<br><br>Replace `YOUR-APP-INSTANCE` with your app instance, `YOUR-SYSLOG-DRAIN` with the name of your syslog drain, and `SYSLOG-DRAIN-URL` with the URL of your syslog drain.
+By default, app logs are included in syslog drains.
+To include container metrics in your syslog drain, an operator must first set `scalablesyslog.adapter.metrics_to_syslog_enabled` to `true`. 
+<%= vars.container_metrics %>
 
 ## <a id='view'></a>Viewing Logs in the Command Line Interface ##
 

--- a/deploy-apps/streaming-logs.html.md.erb
+++ b/deploy-apps/streaming-logs.html.md.erb
@@ -16,7 +16,7 @@ service.
 See [Third-Party Log Management Services](../services/log-management.html).
 
 Cloud Foundry gathers and stores logs in a best-effort manner.
-If a client is unable to consume log lines quickly enough, the Loggregator
+If a client cannot consume log lines quickly enough, the Loggregator
 buffer may need to overwrite some lines before the client has consumed them.
 A syslog drain or a CLI tail can usually keep up with the flow of app
 logs.
@@ -122,7 +122,7 @@ For example:
 
 ### <a id="ssh"></a>SSH ###
 
-The Diego cell emits SSH logs when a user accesses an application container through SSH by using the Cloud Foundry Command Line Interface (cf CLI) [cf ssh](http://cli.cloudfoundry.org/en-US/cf/ssh.html) command.
+The Diego cell emits SSH logs when a user accesses an application container through SSH by using the Cloud Foundry Command Line Interface (cf CLI) [cf ssh](https://cli.cloudfoundry.org/en-US/cf/ssh.html) command.
 
 For example:
 
@@ -154,14 +154,13 @@ performance.
 
 ## <a id='container-metrics'></a> Including Container Metrics in Syslog Drains
 
-By default, app logs are included in syslog drains. To include container metrics in your syslog drain, an operator must first set `scalablesyslog.adapter.metrics_to_syslog_enabled` to `true`. 
-
-Once `scalablesyslog.adapter.metrics_to_syslog_enabled` is set to `true`, run the following cl CLI command: `cf create-drain -metrics YOUR-APP-INSTANCE YOUR-SYSLOG-DRAIN SYSLOG-DRAIN-URL`
+By default, app logs are included in syslog drains. To include container metrics in your syslog drain, an operator must first set `scalablesyslog.adapter.metrics_to_syslog_enabled` to `true`. Once `scalablesyslog.adapter.metrics_to_syslog_enabled` is set to `true`, run the following cf CLI command:
+`cf create-drain -metrics YOUR-APP-INSTANCE YOUR-SYSLOG-DRAIN SYSLOG-DRAIN-URL`
 <br><br>Replace `YOUR-APP-INSTANCE` with your app instance, `YOUR-SYSLOG-DRAIN` with the name of your syslog drain, and `SYSLOG-DRAIN-URL` with the URL of your syslog drain.
 
 ## <a id='view'></a>Viewing Logs in the Command Line Interface ##
 
-You view logs in the CLI using the [cf logs](http://cli.cloudfoundry.org/en-US/cf/logs.html) command.
+Use the cf CLI [cf logs](https://cli.cloudfoundry.org/en-US/cf/logs.html) command to view logs.
 You can tail, dump, or filter log output.
 
 ### <a id="tail-log"></a>Tailing Logs ###
@@ -206,15 +205,12 @@ $ cf logs spring-music --recent | grep -v RTR
 
 Ensuring log ordering in drains can be an important for both operators and developers. However, the Loggregator Firehose does not offer a deterministic routing mechanism for ordering.  
 
-Diego uses a nanosecond-based timestamp that can be ingested properly by Splunk. For more information, see [TIME_FORMAT and subseconds](https://answers.splunk.com/answers/1946/time-format-and-subseconds.html) in the Splunk documentation.
-
-The Elastic Stack can ingest the nanosecond timestamps but only supports millisecond precision, so timestamps are truncated. For more information, see 
-the [Date datatype](https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html) in the Elasticsearch documentation and the [Date type has not enough precision for the logging use case](https://github.com/elastic/elasticsearch/issues/10005) GitHub issue.
+* Diego uses a nanosecond-based timestamp that can be ingested properly by Splunk. For more information, see [TIME_FORMAT and subseconds](https://answers.splunk.com/answers/1946/time-format-and-subseconds.html) in the Splunk documentation.
+* The Elastic Stack can ingest the nanosecond timestamps but only supports millisecond precision, so timestamps are truncated. For more information, see the [Date datatype](https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html) in the Elasticsearch documentation and the [Date type has not enough precision for the logging use case](https://github.com/elastic/elasticsearch/issues/10005) GitHub issue.
 
 If you are developing a client that displays a stream of Cloud Foundry logs to users, you can order the logs to improve the debugging experience for your user. The following are general tips for ordering logs:
 
-* For CLIs, batch the logs and display the logs you have in that timeframe, sorted by timestamp. 
-* For web clients, use dynamic HTML to insert older logs into the sorting as they appear. This creates complete, ordered logs. 
-* Java app developers may want to convert stack traces into a single log entity. To simplify log ordering for Java apps, use the multi-line Java message workaround](https://github.com/cloudfoundry/loggregator-release/blob/develop/docs/java-multi-line-work-around.md) to convert your multi-line stack traces into a single log entity. 
+* For CLIs, batch the logs and display the logs you have in that timeframe, sorted by timestamp.
+* For web clients, use dynamic HTML to insert older logs into the sorting as they appear. This creates complete, ordered logs.
+* Java app developers may want to convert stack traces into a single log entity. To simplify log ordering for Java apps, use the [multi-line Java message workaround](https://github.com/cloudfoundry/loggregator-release/blob/develop/docs/java-multi-line-work-around.md) to convert your multi-line stack traces into a single log entity.
 <br><br>By modifying the Java log output, you can force your app to reformat stack trace messages, replacing newline characters with a token. Set your log parsing code to replace that token with newline characters again to display the logs properly in Kibana.
-

--- a/deploy-apps/streaming-logs.html.md.erb
+++ b/deploy-apps/streaming-logs.html.md.erb
@@ -154,7 +154,14 @@ performance.
 
 ## <a id='container-metrics'></a> Including Container Metrics in Syslog Drains
 
-By default, app logs are included in syslog drains. To include container metrics in your syslog drain, an operator must first set `scalablesyslog.adapter.metrics_to_syslog_enabled` to `true`. Once `scalablesyslog.adapter.metrics_to_syslog_enabled` is set to `true`, run the following cf CLI command:
+By default, app logs are included in syslog drains. To include container metrics in your syslog drain, `scalablesyslog.adapter.metrics_to_syslog_enabled` must be set to `true`&nbsp;. 
+
+<% if not vars.product_full == "Cloud Foundry" %>
+To set this property to `true`, select the **System Logging** pane in <%= vars.product_full%> (<%= vars.product_short%>) and enable the **Include container metrics in SysLog Drains** checkbox. In <%= vars.product_short %> <%= vars.current_major_version.to_f - 0.1 %>, this property is set to `true` by default.
+<% end %>
+
+Once `scalablesyslog.adapter.metrics_to_syslog_enabled` is set to `true`, run the following cf CLI command:
+
 `cf create-drain -metrics YOUR-APP-INSTANCE YOUR-SYSLOG-DRAIN SYSLOG-DRAIN-URL`
 <br><br>Replace `YOUR-APP-INSTANCE` with your app instance, `YOUR-SYSLOG-DRAIN` with the name of your syslog drain, and `SYSLOG-DRAIN-URL` with the URL of your syslog drain.
 

--- a/deploy-apps/streaming-logs.html.md.erb
+++ b/deploy-apps/streaming-logs.html.md.erb
@@ -25,10 +25,10 @@ logs.
 
 Every log line contains four fields:
 
-1. Timestamp
-1. Log type (origin code)
-1. Channel: either `OUT` (logs emitted on `stdout`) or `ERR` (logs emitted on `stderr`)
-1. Message
+* Timestamp
+* Log type (origin code)
+* Channel: Either `OUT`, for logs emitted on `stdout`, or `ERR`, for logs emitted on `stderr`
+* Message
 
 Loggregator assigns the timestamp when it receives log data.
 The log data is opaque to Loggregator, which simply puts it in the message field
@@ -41,13 +41,13 @@ Origin codes from system components have three letters.
 The app origin code is `APP` followed by slash and a digit that
 indicates the app instance.
 
-Many frameworks write to an app log that is separate from STDOUT and
-STDERR.
+Many frameworks write to an app log that is separate from `stdout` and
+`stderr`.
 This is not supported by Loggregator.
-Your app must write to STDOUT or STDERR for its logs to be included in
+Your app must write to `stdout` or `stderr` for its logs to be included in
 the Loggregator stream.
 Check the buildpack your app uses to determine whether it automatically
-ensures that your app correctly writes logs to STDOUT and STDERR only.
+ensures that your app correctly writes logs to `stdout` and `stderr` only.
 Some buildpacks do this, and some do not.
 
 ## <a id='format'></a>Log Types and Their Messages ##
@@ -103,7 +103,7 @@ The following is an example access log message containing Zipkin headers:
 2016-11-23T16:04:01.49-0800 [RTR/0]      OUT www.example.com - [24/11/2016:00:04:01.227 +0000] "GET / HTTP/1.1" 200 0 109 "-" "curl/7.43.0" 10.0.2.150:4070 10.0.48.66:60815 x_forwarded_for:"198.51.100.120" x_forwarded_proto:"http" vcap_request_id:87f9d899-c7a4-46cd-7b76-4ec35ce9921b response_time:0.263000966 app_id:8e5d6451-b369-4423-bce8-3a7a9e479dbb app_index:0 x_b3_traceid:"2d5610bf5e0f7241" x_b3_spanid:"2d5610bf5e0f7241" x_b3_parentspanid:"-"
 </pre>
 
-For more information about Zipkin tracing, see the [Zipkin Tracking in HTTP Headers](../../concepts/http-routing.html#zipkin-headers) topic.
+For more information about Zipkin tracing, see [Zipkin Tracking in HTTP Headers](../../concepts/http-routing.html#zipkin-headers).
 
 ### <a id='lgr'></a>LGR ###
 
@@ -122,7 +122,7 @@ For example:
 
 ### <a id="ssh"></a>SSH ###
 
-The Diego cell emits SSH logs when a user accesses an application container through SSH by using the [cf ssh](http://cli.cloudfoundry.org/en-US/cf/ssh.html) command.
+The Diego cell emits SSH logs when a user accesses an application container through SSH by using the Cloud Foundry Command Line Interface (cf CLI) [cf ssh](http://cli.cloudfoundry.org/en-US/cf/ssh.html) command.
 
 For example:
 
@@ -154,9 +154,10 @@ performance.
 
 ## <a id='container-metrics'></a> Including Container Metrics in Syslog Drains
 
-By default, app logs are included in syslog drains. To include container metrics in your syslog drain, an operator must first set the `scalablesyslog.adapter.metrics_to_syslog_enabled` to `true`. Then you can include the `-metrics` option in the `cf create-drain` command, as shown below.
+By default, app logs are included in syslog drains. To include container metrics in your syslog drain, an operator must first set `scalablesyslog.adapter.metrics_to_syslog_enabled` to `true`. 
 
-<pre class=‘term’>$ cf create-drain -metrics YOUR_APP_INSTANCE YOUR_SYSLOG_DRAIN SYSLOG_DRAIN_URL</pre>
+Once `scalablesyslog.adapter.metrics_to_syslog_enabled` is set to `true`, run the following cl CLI command: `cf create-drain -metrics YOUR-APP-INSTANCE YOUR-SYSLOG-DRAIN SYSLOG-DRAIN-URL`
+<br><br>Replace `YOUR-APP-INSTANCE` with your app instance, `YOUR-SYSLOG-DRAIN` with the name of your syslog drain, and `SYSLOG-DRAIN-URL` with the URL of your syslog drain.
 
 ## <a id='view'></a>Viewing Logs in the Command Line Interface ##
 
@@ -165,7 +166,7 @@ You can tail, dump, or filter log output.
 
 ### <a id="tail-log"></a>Tailing Logs ###
 
-`cf logs APP_NAME` streams Loggregator output to the terminal.
+Run `cf logs APP-NAME` to stream Loggregator output to the terminal. Replace `APP-NAME` with the name of your app.
 
 For example:
 
@@ -183,13 +184,12 @@ Use **Ctrl-C** (^C) to exit the real-time stream.
 
 ### <a id="dump-log"></a>Dumping Logs ###
 
-`cf logs APP_NAME --recent` displays all the lines in the Loggregator buffer.
+Run `cf logs APP-NAME --recent` to display all the lines in the Loggregator buffer. Replace `APP-NAME` with the name of your app.
 
 ### <a id="filter"></a>Filtering Logs ###
 
-To view some subset of log output, use `cf logs` in conjunction with filtering
-commands of your choice.
-In the example below, `grep -v` excludes all Router logs:
+To view some subset of log output, run `cf logs APP-NAME` in conjunction with filtering commands of your choice. Replace `APP-NAME` with the name of your app.
+In the example below, `grep -v RTR` excludes all Router logs:
 
 <pre class="terminal">
 $ cf logs spring-music --recent | grep -v RTR
@@ -202,18 +202,19 @@ $ cf logs spring-music --recent | grep -v RTR
     ...
 </pre>
 
-### <a id=‘log-ordering’></a> Log Ordering
+### <a id='log-ordering'></a> Log Ordering
 
 Ensuring log ordering in drains can be an important for both operators and developers. However, the Loggregator Firehose does not offer a deterministic routing mechanism for ordering.  
 
-For operators configuring syslog drains, it is useful to note that:
+Diego uses a nanosecond-based timestamp that can be ingested properly by Splunk. For more information, see [TIME_FORMAT and subseconds](https://answers.splunk.com/answers/1946/time-format-and-subseconds.html) in the Splunk documentation.
 
-* Diego uses a nanosecond-based timestamp that can be ingested properly by Splunk. For more information, see [these instructions](https://answers.splunk.com/answers/1946/time-format-and-subseconds.html).
-* The Elastic Stack can ingest the nanosecond timestamps but only supports millisecond precision, so timestamps are truncated. For more information, see [ELK's date type](https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html) and the relevant [issue](https://github.com/elastic/elasticsearch/issues/10005).
+The Elastic Stack can ingest the nanosecond timestamps but only supports millisecond precision, so timestamps are truncated. For more information, see 
+the [Date datatype](https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html) in the Elasticsearch documentation and the [Date type has not enough precision for the logging use case](https://github.com/elastic/elasticsearch/issues/10005) GitHub issue.
 
-If you are developing a client that displays a stream of Cloud Foundry logs to users, consider ordering the logs to improve the debugging experience for your user. The following are general tips for ordering logs:
+If you are developing a client that displays a stream of Cloud Foundry logs to users, you can order the logs to improve the debugging experience for your user. The following are general tips for ordering logs:
 
-* Batch the logs and display whatever logs you have in that timeframe sorted by timestamp. This technique is good for CLIs. 
-* For web clients you can use dynamic HTML to insert older logs into the sorting as they appear. This is nice because by the time a user grabs the content for a copy paste, the logs will likely be both complete and in order. 
-* Java app developers may want to convert stack traces into a single log entity. To simplify log ordering for Java apps, use the [multi-line Java message workaround](https://github.com/cloudfoundry/loggregator-release/blob/develop/docs/java-multi-line-work-around.md) to convert your multi-line stack traces into a single log entity. 
-<br><br>By modifying the Java log output, you can make your app reformat your stack trace messages so any newline characters are replaced with a token. Then, you can make your log parsing code replace that token with newline characters again to display the logs properly in Kibana.
+* For CLIs, batch the logs and display the logs you have in that timeframe, sorted by timestamp. 
+* For web clients, use dynamic HTML to insert older logs into the sorting as they appear. This creates complete, ordered logs. 
+* Java app developers may want to convert stack traces into a single log entity. To simplify log ordering for Java apps, use the multi-line Java message workaround](https://github.com/cloudfoundry/loggregator-release/blob/develop/docs/java-multi-line-work-around.md) to convert your multi-line stack traces into a single log entity. 
+<br><br>By modifying the Java log output, you can force your app to reformat stack trace messages, replacing newline characters with a token. Set your log parsing code to replace that token with newline characters again to display the logs properly in Kibana.
+

--- a/deploy-apps/troubleshoot-app-health.html.md.erb
+++ b/deploy-apps/troubleshoot-app-health.html.md.erb
@@ -122,8 +122,7 @@ If this happens, try the following:
     Run `cf events APP-NAME` and `cf logs APP-NAME --recent` and look for
 messages similar to this:
   <pre class="terminal">
-  2014-04-29T17:52:34.00-0700   app.crash          index: 0, reason: CRASHED,
-  exit\_description: app instance exited, exit\_status: 1
+  2018-07-20T15:53:26.00-0700   app.crash                  app-name   index: 2, reason: CRASHED, cell\_id: d874ad05-d0ca-4c63-9f5a-0b1ddd90dd5d, instance: f406c53e-b1ca-4a0f-6140-dddd, exit\_description: APP/PROC/WEB: Exited with status 1
   </pre>
   These messages may identify a memory or port issue.
   If they do, take that as a starting point when you re-examine and fix your

--- a/services/_using-vol-services.html.md.erb
+++ b/services/_using-vol-services.html.md.erb
@@ -49,6 +49,8 @@ To use a volume service deployed by <%= vars.admin %>, you must first create an 
     The following example shows binding `my-app` to the `nfs_service_instance` and specifying a read-only volume to be mounted to `/var/volume1`,
     passing an in-line JSON string:
     <pre class="terminal">$ cf bind-service my-app nfs\_service\_instance -c '{"uid":"1000","gid":"1000","mount":"/var/volume1","readonly":true}'</pre>
+    If you use an LDAP server, you must specify `username` and `password` instead of a UID and GID in this command. For example:
+    <pre class="terminal">$ cf bind-service my-app nfs\_service\_instance -c '{"username":"user1000","password":"secret","mount":"/var/volume1","readonly":true}'</pre>
 
 1. Run `cf restage YOUR-APP` to complete the service binding by restaging your app. Replace `YOUR-APP` with the name of your app.
   <pre class="terminal">$ cf restage my-app</pre>

--- a/services/_using-vol-services.html.md.erb
+++ b/services/_using-vol-services.html.md.erb
@@ -131,7 +131,7 @@ Cloud Foundry offers two NFS volume services:
 * `nfs-experimental`: This volume service provides better performance.
   * It supports NFSv4 through a `version` parameter that determines which NFS protocol to use.
   *  For read-only mounts, the driver enables attribute caching. This results in fewer attribute RPCs and better performance.
-  * It skips mapfs mounting and performs a normal kernel mount of the NFS file system without the overhead associated with FUSE mounts when you omit `uid` and `gid` or `username` and `password` in bind configuration. 
+  * It skips `mapfs` mounting and performs a normal kernel mount of the NFS file system without the overhead associated with FUSE mounts when you omit `uid` and `gid` or `username` and `password` in bind configuration. 
 
 Both services offer a single plan called `Existing`.
 
@@ -152,7 +152,7 @@ Where:
 
 <p class="note"><strong>Note</strong>: Ensure you omit the <code>:</code> that usually follows the server name in the address.</p>
 
-You can run the `cf services` command to confirm that your newly created NFS volume service displays in the output.
+You can run the `cf services` command to confirm that your newly-created NFS volume service displays in the output.
 
 
 #### Create with `nfs-experimental` Service:
@@ -171,13 +171,13 @@ Where:
 
 <p class="note"><strong>Note</strong>: Ensure you omit the <code>:</code> that usually follows the server name in the address.</p>
 
-You can run the `cf services` command to confirm that your newly created NFS volume service displays in the output.
+You can run the `cf services` command to confirm that your newly-created NFS volume service displays in the output.
 
 ### <a id='nfs-sample'></a> Deploy and Bind a Sample App
 
-This section includes a procedure for deploying a sample app and binding it to the NFS volume service.
+This section describes how to deploy a sample app and bind it to the NFS volume service.
 
-1. Clone the github repo and push the pora test app:
+1. Clone the github repo and push the `pora` test app:
   1. `cd ~/workspace`
   1. `git clone https://github.com/cloudfoundry/persi-acceptance-tests.git`
   1. `cd ~/workspace/persi-acceptance-tests/assets/pora`
@@ -191,10 +191,10 @@ This section includes a procedure for deploying a sample app and binding it to t
     Where:
     * `SERVICE-INSTANCE-NAME`: The name of the volume service instance you created previously.
     * `UID` and `GID`: The `gid` and `uid` to use when mounting the share to the app. The NFS driver uses these values in the following ways:
-      * When sending traffic to the nfs server, the NFS driver translates the app user id and group id to the `UID` and `GID` values.
-      * When returning attributes from the nfs server, the NFS driver translates the `UID` and `GID` back to the running user uid and default gid.
+      * When sending traffic to the NFS server, the NFS driver translates the app user id and group id to the `UID` and `GID` values.
+      * When returning attributes from the NFS server, the NFS driver translates the `UID` and `GID` back to the running user uid and default gid.
 
-        This allows you to interact with your nfs server as a specific user while allowing Cloud Foundry to run your application as an arbitrary user.
+        This allows you to interact with your NFS server as a specific user while allowing Cloud Foundry to run your application as an arbitrary user.
     * **Optional paramenters**:
       * `mount`: Use this option to specify the path at which volumes mount to the app container. The default is an arbitrarily-named folder in `/var/vcap/data`. You may need to modify this value if your app has specific requirements. For example:
 
@@ -209,13 +209,13 @@ This section includes a procedure for deploying a sample app and binding it to t
     $ cf start pora
     ```
 
-1. Use the following curl command to confirm the app is running. The command returns an instance index for your app.
+1. Use the following `curl` command to confirm the app is running. The command returns an instance index for your app.
 
     ```
     $ curl http://pora.YOUR-CF-DOMAIN.com
     ```
 
-1. Use the follwing curl command to confirm the app can access the shared volume. The command writes a file to the share and then reads it back out again.
+1. Use the following `curl` command to confirm the app can access the shared volume. The command writes a file to the share and then reads it back out again.
 
     ```
     $ curl http://pora.YOUR-CF-DOMAIN.com/write

--- a/services/_using-vol-services.html.md.erb
+++ b/services/_using-vol-services.html.md.erb
@@ -130,7 +130,7 @@ Cloud Foundry offers two NFS volume services:
 * `nfs`: This volume service is implemented with libfuse. It only supports NFSv3 and has some performance constraints.
 * `nfs-experimental`: This volume service provides better performance.
   * It supports NFSv4 through a `version` parameter that determines which NFS protocol to use.
-  * It uses read-only mounts, which causes the driver to enable attribute caching for mounts. This results in fewer attribute RPCs and better performance.
+  *  For read-only mounts, the driver enables attribute caching. This results in fewer attribute RPCs and better performance.
   * It skips mapfs mounting and performs a normal kernel mount of the NFS file system without the overhead associated with FUSE mounts when you omit `uid` and `gid` or `username` and `password` in bind configuration. 
 
 Both services offer a single plan called `Existing`.

--- a/services/_using-vol-services.html.md.erb
+++ b/services/_using-vol-services.html.md.erb
@@ -113,8 +113,7 @@ To access the volume service from your app, you must know which file path to use
     </tr>
     <tr>
       <td><code>mode</code></td>
-      <td>String that informs what type of access your app has to NFS, either read-only, <code>ro</code>, or read and write, <code>rw</code>.<br><br>
-		Due to an underlying kernel defect, read-only NFS mounts show as <code>"mode": "rw"</code>.
+      <td>String that informs what type of access your app has to NFS, either read-only, <code>ro</code>, or read and write, <code>rw</code>.
 		</td>
     </tr>
   </table>

--- a/services/_using-vol-services.html.md.erb
+++ b/services/_using-vol-services.html.md.erb
@@ -44,7 +44,6 @@ To use a volume service deployed by <%= vars.admin %>, you must first create an 
   * `GID-AND-UID-JSON` (NFS only): If you bind an instance of the NFS volume service, you must supply two extra parameters, `gid` and `uid`. You can specify these parameters with the `-c` flag and a JSON string, in-line or from a file. This parameter specifies the `gid` and `uid` to use when mounting the share to the app.
   * `MOUNT-PATH` (Optional): To mount the volume to a particular path within your app rather than the default path, you supply the `mount` parameter. Choose a path with a root-level folder that already exists in the container, such as `/home`, `/usr`, or `/var`.
   * `READ-ONLY-TRUE` (Optional): When you issue the `cf bind-service` command, Volume Services mounts a read-write file system by default. You can specify a read-only mount by adding `"readonly":true` to the bind configuration JSON string. 
-<p class='note warning'><strong>Warning</strong>: Due to an underlying kernel defect, read-only NFS mounts show as <code>"mode": "rw"</code>, not <code>"mode": "ro"</code>.</p>
 
     The following example shows binding `my-app` to the `nfs_service_instance` and specifying a read-only volume to be mounted to `/var/volume1`,
     passing an in-line JSON string:
@@ -85,7 +84,6 @@ To access the volume service from your app, you must know which file path to use
     ]
   }
   </pre>
-  <p class='note warning'><strong>Warning</strong>: Due to an underlying kernel defect, read-only NFS mounts show as <code>"mode": "rw"</code>, not <code>"mode": "ro"</code>.</p>
 
 2. Use the properties under `volume_mounts` for any information your app needs. Refer to the following table:
   <table>

--- a/services/_using-vol-services.html.md.erb
+++ b/services/_using-vol-services.html.md.erb
@@ -4,6 +4,12 @@
       <li><a href="#pre">Prerequisite</a></li>
       <li><a href="#create">Create and Bind a Service Instance</a></li>
       <li><a href="#app">Access the Volume Service from your App</a></li>
+      <li><a href="#nfs">NFS Volume Service</a></li>
+        <ul>
+          <li><a href="#create-nfs">Create an NFS Volume Service</a></li>
+          <li><a href="#nfs-sample">Deploy and Bind Sample App</a></li>
+          <li><a href="#nfs-additional">Additional Information</a></li>
+        </ul>
     </ul>
   </div>
 </div>
@@ -28,22 +34,24 @@ If no volume service that fits your requirements exists, contact <%= vars.admin 
 
 To use a volume service deployed by <%= vars.admin %>, you must first create an instance of the specific volume service that you need. Follow the instructions below to create this service instance.
 
+<p class="note"><strong>Note</strong>: For NFS-specific instructions and information, see <a href="#nfs">NFS Volume Service</a>.</p>
+
 1. In a terminal window, run `cf create-service SERVICE-NAME PLAN SERVICE-INSTANCE -c SHARE-JSON` to create a service instance. Replace the following with the specified values:
   * `SERVICE`: The name of the volume service that you want to use.
   * `PLAN`: The name of the service plan. Service plans are a way for providers to offer varying levels of resources or features for the same service.
   * `SERVICE-INSTANCE`:  A name you provide for your service instance. Use any series of alpha-numeric characters, hyphens, and underscores. You can rename the instance at any time.
-  * `SHARE-JSON` (NFS Only): If you create an instance of the NFS volume service, you must supply an extra parameter, `share`, by using the `-c` flag with a JSON string, in-line or in a file. This parameter forwards information to the broker about the NFS server and share required for the service. 
-  
-    The following example shows creating an instance of the "Existing" NFS 
-    service plan, passing an in-line JSON string: 
+  * `SHARE-JSON` (NFS Only): If you create an instance of the NFS volume service, you must supply an extra parameter, `share`, by using the `-c` flag with a JSON string, in-line or in a file. This parameter forwards information to the broker about the NFS server and share required for the service.
+
+    The following example shows creating an instance of the "Existing" NFS
+    service plan, passing an in-line JSON string:
     <pre class="terminal">$ cf create-service nfs Existing nfs\_service\_instance -c '{"share": "10.10.10.10/export/myshare"}'</pre>
 
 1. Run `cf bind-service YOUR-APP SERVICE-NAME -c GID-AND-UID-JSON MOUNT-PATH READ-ONLY-TRUE` to bind your service instance to an app. Replace the following with the specified values:
-  * `YOUR-APP`: The name of the <%= vars.product_name %> app for which you want to use the volume service. 
+  * `YOUR-APP`: The name of the <%= vars.product_name %> app for which you want to use the volume service.
   * `SERVICE-NAME`: The name of the volume service instance you created in the previous step.
   * `GID-AND-UID-JSON` (NFS only): If you bind an instance of the NFS volume service, you must supply two extra parameters, `gid` and `uid`. You can specify these parameters with the `-c` flag and a JSON string, in-line or from a file. This parameter specifies the `gid` and `uid` to use when mounting the share to the app.
   * `MOUNT-PATH` (Optional): To mount the volume to a particular path within your app rather than the default path, you supply the `mount` parameter. Choose a path with a root-level folder that already exists in the container, such as `/home`, `/usr`, or `/var`.
-  * `READ-ONLY-TRUE` (Optional): When you issue the `cf bind-service` command, Volume Services mounts a read-write file system by default. You can specify a read-only mount by adding `"readonly":true` to the bind configuration JSON string. 
+  * `READ-ONLY-TRUE` (Optional): When you issue the `cf bind-service` command, Volume Services mounts a read-write file system by default. You can specify a read-only mount by adding `"readonly":true` to the bind configuration JSON string.
 
     The following example shows binding `my-app` to the `nfs_service_instance` and specifying a read-only volume to be mounted to `/var/volume1`,
     passing an in-line JSON string:
@@ -110,3 +118,131 @@ To access the volume service from your app, you must know which file path to use
 		</td>
     </tr>
   </table>
+
+## <a id='nfs'></a> NFS Volume Service
+
+This section describes how to use the NFS volume service.
+
+### <a id='create-nfs'></a> Create an NFS Volume Service
+
+Cloud Foundry offers two NFS volume services:
+
+* `nfs`: This volume service is implemented with libfuse. It only supports NFSv3 and has some performance constraints.
+* `nfs-experimental`: This volume service provides better performance.
+  * It supports NFSv4 through a `version` parameter that determines which NFS protocol to use.
+  * It uses read-only mounts, which causes the driver to enable attribute caching for mounts. This results in fewer attribute RPCs and better performance.
+  * It skips mapfs mounting and performs a normal kernel mount of the NFS file system without the overhead associated with FUSE mounts when you omit `uid` and `gid` or `username` and `password` in bind configuration. 
+
+Both services offer a single plan called `Existing`.
+
+To create an NFS volume service, follow the procedure below that corresponds to your use case.
+
+#### Create with `nfs` Service
+
+You can create a NFS volume service with NFSv3 using the `Existing` plan of the `nfs` service. Run the following command:
+
+```
+$ cf create-service nfs Existing SERVICE-INSTANCE-NAME -c '{"share":"SERVER/SHARE"}'
+```
+
+Where:
+
+* `SERVICE-INSTANCE-NAME` is a name you provide for this NFS volume service instance.
+* `SERVER/SHARE` is the NFS address of your server and share.
+
+<p class="note"><strong>Note</strong>: Ensure you omit the <code>:</code> that usually follows the server name in the address.</p>
+
+You can run the `cf services` command to confirm that your newly created NFS volume service displays in the output.
+
+
+#### Create with `nfs-experimental` Service:
+
+You can create a NFS volume service with NFSv3 or NFSv4 using the `Existing` plan of the `nfs-experimental` service. Run the following command:
+
+```
+$ cf create-service nfs-experimental Existing SERVICE-INSTANCE-NAME -c '{"share":"SERVER/SHARE", "version":"NFS-PROTOCOL"}'
+```
+
+Where:
+
+* `SERVICE-INSTANCE-NAME` is a name you provide for this NFS volume service instance.
+* `SERVER/SHARE` is the NFS address of your server and share.
+* `VERSION` is the NFS protocol you want to use. For example, if you want to use NFSv4, set the version to `4.1`.
+
+<p class="note"><strong>Note</strong>: Ensure you omit the <code>:</code> that usually follows the server name in the address.</p>
+
+You can run the `cf services` command to confirm that your newly created NFS volume service displays in the output.
+
+### <a id='nfs-sample'></a> Deploy and Bind a Sample App
+
+This section includes a procedure for deploying a sample app and binding it to the NFS volume service.
+
+1. Clone the github repo and push the pora test app:
+  1. `cd ~/workspace`
+  1. `git clone https://github.com/cloudfoundry/persi-acceptance-tests.git`
+  1. `cd ~/workspace/persi-acceptance-tests/assets/pora`
+  1. `cf push pora --no-start`
+
+1. To bind the service to your app, run the following command:
+
+    ```
+    $ cf bind-service pora SERVICE-INSTANCE-NAME -c '{"uid":"UID","gid":"GID"}'
+    ```
+    Where:
+    * `SERVICE-INSTANCE-NAME`: The name of the volume service instance you created previously.
+    * `UID` and `GID`: The `gid` and `uid` to use when mounting the share to the app. The NFS driver uses these values in the following ways:
+      * When sending traffic to the nfs server, the NFS driver translates the app user id and group id to the `UID` and `GID` values.
+      * When returning attributes from the nfs server, the NFS driver translates the `UID` and `GID` back to the running user uid and default gid.
+
+        This allows you to interact with your nfs server as a specific user while allowing Cloud Foundry to run your application as an arbitrary user.
+    * **Optional paramenters**:
+      * `mount`: Use this option to specify the path at which volumes mount to the app container. The default is an arbitrarily-named folder in `/var/vcap/data`. You may need to modify this value if your app has specific requirements. For example:
+
+            ```
+            cf bind-service pora myVolume -c '{"uid":"0","gid":"0","mount":"/var/path"}'
+            ```
+      * `readonly`: When you issue the `cf bind-service` command, Volume Services mounts a read-write file system by default. You can specify a read-only mount by adding `"readonly":true` to the bind configuration JSON string.
+
+1. Start the app:
+
+    ```
+    $ cf start pora
+    ```
+
+1. Use the following curl command to confirm the app is running. The command returns an instance index for your app.
+
+    ```
+    $ curl http://pora.YOUR-CF-DOMAIN.com
+    ```
+
+1. Use the follwing curl command to confirm the app can access the shared volume. The command writes a file to the share and then reads it back out again.
+
+    ```
+    $ curl http://pora.YOUR-CF-DOMAIN.com/write
+    ```
+
+### <a id="nfs-additional"></a> Additional Information
+
+This section provides additional information about using the NFS Volume Service.
+
+#### Binding with LDAP Credentials
+
+If your Cloud Foundry deployment has LDAP enabled, you can bind using LDAP credentials.
+
+To bind an app to your volume using LDAP credentials, specify `username` and `password` instead of `uid` and `gid`. See the following example:
+
+```
+$ cf bind-service pora myVolume -c '{"username":"USERNAME","password":"PASSWORD"}'
+```
+
+<p class="note"><strong>Note</strong>: If your LDAP server password changes, you must re-bind your app to the service and restage. If you do not, your app will fail during restart or scaling. This is because user credentials are stored as part of the service binding and checked whenever an app is placed on a cell.</p>
+
+#### Specifying Bind Parameters During Service Instance Creation
+
+As of `nfs-volume-release` v1.3.1, you can specify bind parameters in advance, when you create a service instance. Use this option if you bind the service to your app in an app manifest, where bind configuration is not supported.
+
+#### File Locking with `flock()` and `lockf()`/`fcntl()`
+
+For apps that use file locking through unix system calls such as `flock()` and `fcntl()` or script commands such as `flock`, NFS volume service does not enforce the locking across Diego cells. This is because the file locking capability of the underlying `fuse-nfs` executable is not implemented. Locking is therefore limited to local locks between precesses on the same VM.
+
+If you have a requirement for file locking, describe your use case in the following Github issue for consideration by the Diego Persistence team: [lock not propagated between instances](https://github.com/cloudfoundry-incubator/nfs-volume-release/issues/13).

--- a/services/application-binding.html.md.erb
+++ b/services/application-binding.html.md.erb
@@ -70,11 +70,11 @@ For more information about application manifests, see [Deploying with Applicatio
 
 ### <a id='service-binding-names'></a>Named Service Bindings ###
 
-Service offering and service instance names may vary across the environments an app is deployed to. App authors need to discover the service instances their apps need, without having to know environment-specific service names. To make this easy, deployers can specify a service binding name that will be included in [VCAP_SERVICES](../deploy-apps/environment-variable.html).
+Service offering and service instance names vary across environments. App authors can discover the service instances their apps require, without having to know environment-specific service names. Developers can specify a service binding name to be included in [VCAP_SERVICES](../deploy-apps/environment-variable.html).
 
 To specify the service binding name, provide the `--binding-name` flag when binding an app to a service instance:
 <pre class="terminal">
-cf bind-service my-app my-service --binding-name postgres-database
+$ cf bind-service my-app my-service --binding-name postgres-database
 OK
 </pre>
 

--- a/services/application-binding.html.md.erb
+++ b/services/application-binding.html.md.erb
@@ -26,7 +26,7 @@ $ cf restart my-app
 
 ### <a id='arbitrary-params-binding'></a> Arbitrary Parameters  ###
 
-_Arbitrary parameters require Cloud Foundry Command Line Interface (cf CLI)cf CLI v6.12.1 or later._
+_Arbitrary parameters require Cloud Foundry Command Line Interface (cf CLI) v6.12.1 or later._
 
 Some services support additional configuration parameters with the bind request. These parameters are passed in a valid JSON object containing service-specific configuration parameters, provided either in-line or in a file. For a list of supported configuration parameters, see documentation for the particular service offering.
 

--- a/services/application-binding.html.md.erb
+++ b/services/application-binding.html.md.erb
@@ -68,6 +68,30 @@ OK
 
 For more information about application manifests, see [Deploying with Application Manifests](../deploy-apps/manifest.html#services-block).
 
+### <a id='service-binding-names'></a>Named Service Bindings ###
+
+Service offering and service instance names may vary across the environments an app is deployed to. App authors need to discover the service instances their apps need, without having to know environment-specific service names. To make this easy, deployers can specify a service binding name that will be included in [VCAP_SERVICES](../deploy-apps/environment-variable.html).
+
+To specify the service binding name, provide the `--binding-name` flag when binding an app to a service instance:
+<pre class="terminal">
+cf bind-service my-app my-service --binding-name postgres-database
+OK
+</pre>
+
+The provided name will be available in the `name` and `binding_name` properties in the [VCAP_SERVICES](../deploy-apps/environment-variable.html) environment variable:
+
+~~~
+"VCAP_SERVICES": {
+  "service-name": [
+    {
+      "name": "postgres-database",
+      "binding_name": "postgres-database",
+      ...
+    }
+  ]
+}
+~~~
+
 ### <a id='use'></a>Using Bound Service Instances ###
 
 Once you have a service instance created and bound to your application, you need to configure the application to dynamically fetch the credentials for your service instance. The [VCAP_SERVICES](../deploy-apps/environment-variable.html#VCAP-SERVICES) environment variable contains credentials and additional metadata for all bound service instances. There are two methods developers can leverage to have their applications consume binding credentials.

--- a/services/index.html.md.erb
+++ b/services/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Services Overview
-owner: Core Services
+owner: Services API
 ---
 
 <strong><%= modified_date %></strong>

--- a/v3-commands.html.md.erb
+++ b/v3-commands.html.md.erb
@@ -31,8 +31,8 @@ Consult the following table for a description of the experimental commands.
 <th>Description</th>
 </tr>
 <tr>
-<td><code>v3-app</code></td>
-<td>Retrieves and display an app's GUID, suppressing all other health and status output</td>
+<td><code>v3-apply-manifest</code></td>
+<td>Applies manifest properties to an application</td>
 </tr>
 <tr>
 <td><code>v3-apps</code></td>


### PR DESCRIPTION
The documentation for the 'memory' attribute in the manifest.yml seemed ambiguous, in comparison to what is mentioned for the 'disk_quota' attribute.
https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#memory
https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#disk-quota

The actual behavior of the memory attribute is to provide X M/GB/MB etc of memory to 'each' app instance, rather than for all instances of the app.

The proposed change is to update the documentation for 'memory' to be more clear.