### PR TITLE
Remove V3-APP From List of Experimental

### DIFF
--- a/v3-commands.html.md.erb
+++ b/v3-commands.html.md.erb
@@ -31,10 +31,6 @@ Consult the following table for a description of the experimental commands.
 <th>Description</th>
 </tr>
 <tr>
-<td><code>v3-app</code></td>
-<td>Retrieves and display an app's GUID, suppressing all other health and status output</td>
-</tr>
-<tr>
 <td><code>v3-apply-manifest</code></td>
 <td>Applies manifest properties to an application</td>
 </tr>


### PR DESCRIPTION
Please do not pull this in yet, thank you.
This command no longer exist with 6.38.0; it has been integrated into `cf app`.