### PR TITLE
Fix typo in manifest.html.md.erb

### DIFF
--- a/deploy-apps/manifest.html.md.erb
+++ b/deploy-apps/manifest.html.md.erb
@@ -576,7 +576,7 @@ This manifest pushes two apps, smallapp and bigapp, with the staticfile buildpac
 
 Variable substitution replaces [Inheritance](#inheritance-deprecated), which has been deprecated.  
 
-Value substitution allow app developers to create app manifests with values shared across all applicable environments in combination with references to environment-specific differences defined in separate files. It addition, using variable substitution enables developers to store sensitive data in a separate file that the app manifest would reference, making the security sensitive data easier to manage and keep secure.
+Value substitution allow app developers to create app manifests with values shared across all applicable environments in combination with references to environment-specific differences defined in separate files. In addition, using variable substitution enables developers to store sensitive data in a separate file that the app manifest would reference, making the security sensitive data easier to manage and keep secure.
 
 To utilize this feature, your app manifest requires an explicit declaration that the app or app configuration requires additional data. Use template variables in parentheses in your app manifest in place of fixed values.
 


### PR DESCRIPTION
Fixes typo by changing:
> It addition, ...

to:

> In addition, ...