### PR TITLE
Update the URL to Policy Server External API

### DIFF
--- a/deploy-apps/cf-networking.html.md.erb
+++ b/deploy-apps/cf-networking.html.md.erb
@@ -45,7 +45,7 @@ This topic describes how to configure the Container-to-Container Networking feat
 
 This section describes how to create and modify Container-to-Container Networking policies using the Cloud Foundry Command Line Interface (cf CLI).
 The cf CLI only supports configuring policies for apps within the same space. 
-To configure policies for apps in different orgs and spaces, use the [Policy Server External API](https://github.com/cloudfoundry/cf-networking-release/blob/v1.10.x/docs/API.md).
+To configure policies for apps in different orgs and spaces, use the [Policy Server External API](https://github.com/cloudfoundry/cf-networking-release/blob/develop/docs/API_v0.md).
 
 <p class='note'><strong>Note:</strong> With the NSX-T integration, container networking policies and ASGs continue to work as normal. Advanced ASG logging is not supported with NSX-T.</p>
 


### PR DESCRIPTION
Noticed the URL for Policy Server External API was broken. I believe I found the correct URL