### PR TITLE
Update for SD internal cli feature

### DIFF
--- a/deploy-apps/routes-domains.html.md.erb
+++ b/deploy-apps/routes-domains.html.md.erb
@@ -77,6 +77,25 @@ TCP routes include a domain and a route port. A route port is the port clients m
 
 Apps can communicate without leaving the platform on the container network using internal routes. You can create an internal route using the [cf map-route](#map-internal-route) command with an [internal domain](#internal-domains).
 
+After an internal route is mapped to an application, the route resolves to IP addresses
+of the application instances. The IP addresses are visible in the application container.
+
+<pre class="terminal">
+$ cf map-route app apps.internal --hostname app
+$ cf ssh app
+vcap@1234:~$ host app.apps.internal
+app.apps.internal has address 10.255.169.200
+app.apps.internal has address 10.255.49.7
+app.apps.internal has address 10.255.49.77
+</pre>
+
+To resolve individual instances, prepend the index to the internal route.
+
+<pre class="terminal">
+vcap@1234:~$ host 1.app.apps.internal
+1.app.apps.internal has address 10.255.49.7
+</pre>
+
 By default, apps cannot communicate with each other on the container network. To allow apps to communicate with each other you must create a network policy. For more information, see [add-network-policy](https://cli.cloudfoundry.org/en-US/cf/add-network-policy.html) in the _Cloud Foundry CLI Reference Guide_.
 
 ### <a id='create-route'></a> Create a Route
@@ -501,27 +520,15 @@ $ cf delete-shared-domain example.com
 
 The internal domain is a special type of shared domain used for app communication internal
 to the platform. When you enable service discovery, the internal domain `apps.internal`
-becomes available for route mapping. Administrators can configure multiple internal
-domains.
+becomes available for route mapping.
 
-After an internal route is mapped to an application, the route resolves to IP addresses
-of the application instances. The IP addresses are visible in the application container.
-
+Admins can configure multiple internal domains. First add a custom internal domain name to the `internal_domains` property on the `bosh-dns-adapter` job.
+Then create an internal domain using the `--internal` option:
 <pre class="terminal">
-$ cf map-route app apps.internal --hostname app
-$ cf ssh app
-vcap@1234:~$ host app.apps.internal
-app.apps.internal has address 10.255.169.200
-app.apps.internal has address 10.255.49.7
-app.apps.internal has address 10.255.49.77
+$ cf create-shared-domain <%=vars.app_domain%> --internal
 </pre>
 
-To resolve individual instances, prepend the index to the internal route.
-
-<pre class="terminal">
-vcap@1234:~$ host 1.app.apps.internal
-1.app.apps.internal has address 10.255.49.7
-</pre>
+The `--router-group` option is not used with internal domains.
 
 ### <a id='private-domains'></a> Private Domains
 


### PR DESCRIPTION
Update docs for SD internal cli feature:
- Added cli command in Internal Domain section
- Moved map-route details to Internal Routes section

https://docs.cloudfoundry.org/devguide/deploy-apps/routes-domains.html

See #161940347