### PR TITLE
overlay network cidr example ops file improvement

### DIFF
--- a/deploy-apps/_c2c_oss_enable.html.md.erb
+++ b/deploy-apps/_c2c_oss_enable.html.md.erb
@@ -37,7 +37,7 @@ Container networking has properties that you can configure to change their defau
   <tr>
     <td><pre><code>
     - type: replace
-    path: /instance_groups/name=diego-cell/jobs/name=silk-controller/properties/network?
+    path: /instance_groups/name=diego-api/jobs/name=silk-controller/properties/network?
     value: REPLACE-WITH-OVERLAY-NETWORK-CIDR
     </code></pre></td>
     <td>


### PR DESCRIPTION
Recently we tried to follow the docs and encountered a tiny issuette.

diego-cell instance group does not have a job called silk-controller.

silk-controller runs on the diego-api component.

We wrote an ops file and implemented the change. It seems to work so we're confident that it's a valid doc fix