### PR TITLE
clarify docker app tag behavior

### DIFF
--- a/deploy-apps/push-docker.html.md.erb
+++ b/deploy-apps/push-docker.html.md.erb
@@ -29,6 +29,8 @@ To push apps with Docker, you need the following:
 * A registry that supports the [Docker Registry HTTP API V2](https://docs.docker.com/registry/spec/api/) and presents a valid certificate for HTTPS traffic.
 
 <p class="note"><strong>Note</strong>: If you want to log in to your app container using the <code>cf ssh</code> command, a shell such as <code>sh</code> or <code>bash</code> must be available in the container. The SSH server in the container looks for the following executables in absolute locations or the <code>PATH</code> environment variable: <code>/bin/bash</code>, <code>/usr/local/bin/bash</code>, <code>/bin/sh</code>, <code>bash</code>, and <code>sh</code>.</p>
+<p class="note"><strong>Note</strong>: If you want your app container to be consistent through platform updates and code changes, you should always push with a tag, otherwise the plaform will run the tag <code>latest</code> without respecting changes to PORT or ENTRYPOINT.</p>
+<p class="note"><strong>Note</strong>: If you push without a tag, you will need to `cf restage` manually for changes to take effect.</p>
 
 ## <a id='port_config'></a>Port Configuration
 
@@ -57,7 +59,7 @@ To deploy a Docker image from a Docker Hub repository, run `cf push APP-NAME --d
 * `APP-NAME`: The name of the app being pushed
 * `REPO`: The name of the repository where the image is stored
 * `IMAGE`: The name of an image from Docker Hub
-* `TAG`: (Optional) The tag or version for the image
+* `TAG`: (Optional, recommended) The tag or version for the image
 
 For example, the following command pushes the `my-image` image from Docker Hub to a Cloud Foundry app:
 
@@ -74,7 +76,7 @@ To deploy a Docker image using a specified Docker registry, run `cf push APP-NAM
 * `PORT`: The port where the registry serves traffic
 * `REPO`: The name of the repository where the image is stored
 * `IMAGE`: The name of the image being pushed
-* `TAG`: (Optional) The tag or version for the image
+* `TAG`: (Optional, recommended) The tag or version for the image
 
 For example, the following command pushes the `v2` version of the `my-image` image from the `my-repo` repository of the `internal-registry.example.com` registry on port `5000`:
 
@@ -94,7 +96,7 @@ Many Docker registries control access to Docker images by authenticating with a 
       - For Docker Hub, this is just the repository name
       - For a private registry, this includes the registry address and port, as described in [Push a Docker Image from a Private Registry](#private), in the format: `MY-PRIVATE-REGISTRY.DOMAIN:PORT/REPO`
   - `IMAGE`: The name of the image being pushed
-  - `TAG`: (Optional) The tag or version for the image
+  - `TAG`: (Optional, recommended) The tag or version for the image
   - `USER`: The username to use for authentication with the registry
 
 ##<a id='gcr'></a>Push a Docker Image From Google Container Registry (GCR)


### PR DESCRIPTION
provided explicit recommendations to use tags and explain the consequences of not doing so