### PR TITLE
healthchecks: Add warning for http healthcheck

### DIFF
--- a/deploy-apps/healthchecks.html.md.erb
+++ b/deploy-apps/healthchecks.html.md.erb
@@ -113,7 +113,7 @@ The following table describes the types of health checks available for apps and 
 <tr>
 <td><code>http</code></td>
 <td>The app can provide an <code>HTTP 200</code> response.</td>
-<td>The <code>http</code> health check performs a GET request to the configured HTTP endpoint on the app's default port. When the health check receives an <code>HTTP 200</code> response, the app is declared healthy. We recommend using the <code>http</code> health check type whenever possible. A healthy HTTP response ensures that the web app is ready to serve HTTP requests. The configured endpoint must respond within 1 second to be considered healthy. <strong>WARNING:</strong> To prevent false-negatives it is recommended to use dedicated endpoint for healthcheck where response time and result do not depend on business logic.</td>
+<td>The <code>http</code> health check performs a GET request to the configured HTTP endpoint on the app's default port. When the health check receives an <code>HTTP 200</code> response, the app is declared healthy. We recommend using the <code>http</code> health check type whenever possible. A healthy HTTP response ensures that the web app is ready to serve HTTP requests. The configured endpoint must respond within 1 second to be considered healthy.<br><strong>WARNING:</strong> To prevent false negatives, use a dedicated endpoint for healthcheck where response time and result do not depend on business logic.</td>
 </tr>
 <tr>
 <td><code>port</code></td>


### PR DESCRIPTION
Make it explicit that http-healthcheck should be used with dedicated endpoint to prevent false-negatives and cascading failures.