### PR TITLE
Documentation on changing application stacks might cause confusions.

### DIFF
--- a/deploy-apps/stacks.html.md.erb
+++ b/deploy-apps/stacks.html.md.erb
@@ -8,7 +8,7 @@ owner:
 
 <strong><%= modified_date %></strong>
 
-This topic explains how to restage apps on a new stack. It also provides a description of stacks and lists the supported stacks on <%= vars.current_major_version ?  "#{vars.product_full} (#{vars.product_short}) v#{vars.current_major_version}" : vars.product_full %>. 
+This topic explains how to cgange applications stacks. It also provides a description of stacks and lists the supported stacks on <%= vars.current_major_version ?  "#{vars.product_full} (#{vars.product_short}) v#{vars.current_major_version}" : vars.product_full %>. 
 
 You can also use the Stack Auditor plugin for the Cloud Foundry Command Line Interface (cf CLI) when changing stacks. See [Using the Stack Auditor Plugin](../../adminguide/stack-auditor.html).
 
@@ -49,7 +49,7 @@ It can be difficult to know what libraries an app statically links to, and it de
     cflinuxfs2      Cloud Foundry Linux-based file system
     </pre>
 
-1. To change your stack and restage your app, run `cf push`. For example, to restage your app on the stack `cflinuxfs3`, run `cf push MY-APP -s cflinuxfs3`:
+1. To change your stack you have to push your application again. Run `cf push` in the application directory. For example, change the stack of your application to `cflinuxfs3`, run `cf push MY-APP -s cflinuxfs3`:
     <pre class='terminal'>
     $ cf push MY-APP
     Using stack cflinuxfs2...


### PR DESCRIPTION
Hi,
We just finished figuring out a customer issue that bottled down to him getting confused while changing his application stack and following the documentation. What I believe might have caused the confusion is the fact that the documentation mentions several times that the application has to be 'restaged' while actually the application is pushed again on the new stack. 

The problem is that with 'restage' the application files are taken from CC and with 'push' they are updated, meaning that push has to be executed from the application directory to avoid errors. With our customer the problem was exactly that. He was executing the push from a different directory, assuming that it will simply 'restage' with the new stack without updating the files.

I proposed some changes to the wording.

Best Regards,
Desislava