### PR TITLE
Update manifest-attributes.html.md.erb

### DIFF
--- a/deploy-apps/manifest-attributes.html.md.erb
+++ b/deploy-apps/manifest-attributes.html.md.erb
@@ -388,9 +388,7 @@ For example:
   timeout: 80
 </pre>
 
-You can increase the timeout length for very large apps that require more time to start. The `timeout` attribute defaults to 60, but you can set it to any value up to the Cloud Controller's `cc.maximum_health_check_timeout` property.
-
-`cc.maximum_health_check_timeout` defaults to 180, but your Cloud Foundry operator can set to any value.
+You can increase the timeout length for very large apps that require more time to start. The `timeout` attribute defaults to 60, but you can set it to any value up to the Cloud Controller's `cc.maximum_health_check_timeout` property, which is 180 seconds. On PWS this is set by Pivotal and cannot be increased.
 
 The command line option that overrides the timeout attribute is `-t`.
 


### PR DESCRIPTION
Health Check Timeout. 

Removing this, " cc.maximum_health_check_timeout defaults to 180, but your Cloud Foundry operator can set to any value. ", as it is incorrect.