### PR TITLE
Fix improper wording in managing-services docs 

### DIFF
--- a/services/managing-services.html.md.erb
+++ b/services/managing-services.html.md.erb
@@ -42,7 +42,7 @@ OK
 
 <strong>User Provided Service Instances</strong> provide a way for developers to bind apps with services that are not available in their Cloud Foundry marketplace. For more information, see the <a href="./user-provided.html">User Provided Service Instances</a> topic.
 
-<p class="note"><strong>Note</strong>: When multiple brokers provide two or more service instances with the same name, you must specify the broker by including the <code>-b BROKER</code> flag in the <code>cf create-service</code> command.</p>
+<p class="note"><strong>Note</strong>: When multiple brokers provide two or more services with the same name, you must specify the broker by including the <code>-b BROKER</code> flag in the <code>cf create-service</code> command.</p>
 
 ### <a id='arbitrary-params-create'></a> Arbitrary Parameters  ###
 


### PR DESCRIPTION
The command `create-service` have notes that use the term service instance which is not correct in the context since it refers to services
More information on the [tracker story](https://www.pivotaltracker.com/story/show/165760197)

Best Regards,
Niki
On behalf of SAPI Team