### PR TITLE
c2c overlay overlay configuration corrected

### DIFF
--- a/deploy-apps/_c2c_oss_overlay.html.md.erb
+++ b/deploy-apps/_c2c_oss_overlay.html.md.erb
@@ -16,7 +16,7 @@ If you want to modify the number of Diego cells supported by the overlay network
   </tr>
   <tr>
     <td>/20</td>
-    <td>63</td>
+    <td>15</td>
     <td>254</td>
   </tr>
   <tr>


### PR DESCRIPTION
The number of cells that can be supported with a overlay subnet mask
of /20 is 15 cells.

The calculation for this is 2^(24-20) for 16 total, with one reserved
subnet for the single-ip-only range.