### PR TITLE
Update manifest-attributes.html.md.erb

### DIFF
--- a/deploy-apps/manifest-attributes.html.md.erb
+++ b/deploy-apps/manifest-attributes.html.md.erb
@@ -390,7 +390,7 @@ For example:
 
 You can increase the timeout length for very large apps that require more time to start. The `timeout` attribute defaults to 60, but you can set it to any value up to the Cloud Controller's `cc.maximum_health_check_timeout` property.
 
-`cc.maximum_health_check_timeout` defaults to 180. <%= vars.max_healthcheck_timeout %>
+`cc.maximum_health_check_timeout` defaults to the maximum of 180. <%= vars.max_healthcheck_timeout %>
 
 The command line option that overrides the timeout attribute is `-t`.
 


### PR DESCRIPTION
`cc.maximum_health_check_timeout` defaults to 180 --> `cc.maximum_health_check_timeout` defaults to the maximum of 180.

PWS's Health Check Timeout is set to a minimum of 60 seconds and that can be configureable to a maximum of 180 seconds. If you try to configure the timeout above 180 seconds, the CAPI will give you an error. Below is a link to the PWS Health Check Timeout.