### PR TITLE
buildpack -> buildpacks

### DIFF
--- a/deploy-apps/manifest-attributes.html.md.erb
+++ b/deploy-apps/manifest-attributes.html.md.erb
@@ -49,7 +49,8 @@ To add variables to an app manifest, do the following:
     - name: test-app
       instances: ((instances))
       memory: ((memory))
-      buildpack: go_buildpack
+      buildpacks:
+      - go_buildpack
       env:
         GOPACKAGENAME: go_calls_ruby
       command: go_calls_ruby


### PR DESCRIPTION
[The `buildpack:` attribute is deprecated.](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#buildpack)