### PR TITLE
Fix find-app link in app manifest topic

### DIFF
--- a/deploy-apps/manifest-attributes.html.md.erb
+++ b/deploy-apps/manifest-attributes.html.md.erb
@@ -289,7 +289,7 @@ The command line option that overrides this attribute is `-p`.
   path: /path/to/app/bits
 </pre>
 
-For more information, see the [How cf push Finds the App](#find-app) topic.
+For more information, see the [How cf push Finds the App](https://docs.cloudfoundry.org/cf-cli/getting-started.html#find-app) topic.
 
 ### <a id='random-route'></a> random-route
 


### PR DESCRIPTION
I noticed this link was broken in the docs. The section was moved to the cf cli docs in [a commit a few months ago](https://github.com/cloudfoundry/docs-cf-cli/commit/6ad68cc550edc8be745b60dfbc2e19cd4cb0e611\#diff-c06c40a24f88e96bae204d1df4014664) but the link was not updated to reflect this.