### PR TITLE
Be explicit on when .profile gets run, and give an example

### DIFF
--- a/deploy-apps/deploy-app.html.md.erb
+++ b/deploy-apps/deploy-app.html.md.erb
@@ -211,7 +211,7 @@ For more information, see the [Ignore Unnecessary Files When Pushing](./prepare-
 
 You can configure `cf push` to run custom initialization tasks for an app.
 
-These tasks run after <%= vars.product_short %> loads the app's buildpack, but before it launches the app itself, in order to let the initialization script access the app's language runtime environment.
+These tasks run after <%= vars.product_short %> loads the app's droplet, but before it launches the app itself, in order to let the initialization script access the app's language runtime environment. For example, your script might map values from `$VCAP_SERVICES` into other environment variables, or into a config file that the app uses.
 
 To run initialization tasks:
 

--- a/deploy-apps/deploy-app.html.md.erb
+++ b/deploy-apps/deploy-app.html.md.erb
@@ -211,7 +211,7 @@ For more information, see the [Ignore Unnecessary Files When Pushing](./prepare-
 
 You can configure `cf push` to run custom initialization tasks for an app.
 
-These tasks run after <%= vars.product_short %> loads the app's droplet, but before it launches the app itself, in order to let the initialization script access the app's language runtime environment. For example, your script might map values from `$VCAP_SERVICES` into other environment variables, or into a config file that the app uses.
+These tasks run after <%= vars.product_short %> loads the app droplet but before it launches the app itself to let the initialization script access the app language runtime environment. For example, your script can map values from `$VCAP_SERVICES` into other environment variables or a config file that the app uses.
 
 To run initialization tasks:
 


### PR DESCRIPTION
The existing language confused a colleague of mine into thinking that .profile was a staging-time thing. [It's not...](https://github.com/cloudfoundry/buildpackapplifecycle/blob/master/launcher/launcher_unix.go#L25-L27) This change will hopefully avoid that confusion for others. It also suggests an example that could only make sense at app-start time.