### PR TITLE
Document organization guid and name in VCAP_APPLICATION env vars

### DIFF
--- a/deploy-apps/environment-variable.html.md.erb
+++ b/deploy-apps/environment-variable.html.md.erb
@@ -405,6 +405,14 @@ The table below lists the attributes that are returned.
     <td>Human-readable name of the organization where the app is deployed.</td>
   </tr>
   <tr>
+    <td><code>process_id</code></td>
+    <td>GUID identifying the process.  Only present in running app containers.</td>
+  </tr>
+  <tr>
+    <td><code>process_type</code></td>
+    <td>Type of the process.  Only present in running app containers.</td>
+  </tr>
+  <tr>
     <td><code>space_id</code></td>
     <td>GUID identifying the app's space.</td>
   </tr>

--- a/deploy-apps/environment-variable.html.md.erb
+++ b/deploy-apps/environment-variable.html.md.erb
@@ -45,6 +45,7 @@ System-Provided:
   },
   "name": "my-app",
   "organization_id": "c0134bad-97a9-468d-ab9d-e97547e3aed5",
+  "organization_name": "my-org",
   "space_id": "06450c72-4669-4dc6-8096-45f9777db68a",
   "space_name": "my-space",
   "uris": [
@@ -400,6 +401,10 @@ The table below lists the attributes that are returned.
     <td>GUID identifying the app's organization.</td>
   </tr>
   <tr>
+    <td><code>organization_name</code></td>
+    <td>Human-readable name of the organization where the app is deployed.</td>
+  </tr>
+  <tr>
     <td><code>space_id</code></td>
     <td>GUID identifying the app's space.</td>
   </tr>
@@ -633,6 +638,7 @@ System-Provided:
   },
   "name": "APP-NAME",
   "organization_id": "c0134bad-97a9-468d-ab9d-e97547e3aed5",
+  "organization_name": "my-org",
   "space_id": "37189599-2407-9946-865e-8ebd0e2df89a",
   "space_name": "dev",
   "uris": [

--- a/deploy-apps/environment-variable.html.md.erb
+++ b/deploy-apps/environment-variable.html.md.erb
@@ -34,7 +34,7 @@ System-Provided:
   "application_id": "fa05c1a9-0fc1-4fbd-bae1-139850dec7a3",
   "application_name": "my-app",
   "application_uris": [
-    "my-app.192.0.2.34.xip.io"
+    "my-app.example.com"
   ],
   "application_version": "fb8fbcc6-8d58-479e-bcc7-3b4ce5a7f0ca",
   "cf_api": "https://api.example.com",
@@ -44,10 +44,11 @@ System-Provided:
     "mem": 256
   },
   "name": "my-app",
+  "organization_id": "c0134bad-97a9-468d-ab9d-e97547e3aed5",
   "space_id": "06450c72-4669-4dc6-8096-45f9777db68a",
   "space_name": "my-space",
   "uris": [
-    "my-app.192.0.2.34.xip.io"
+    "my-app.example.com"
   ],
   "users": null,
   "version": "fb8fbcc6-8d58-479e-bcc7-3b4ce5a7f0ca"
@@ -395,6 +396,10 @@ The table below lists the attributes that are returned.
     <td>Identical to <code>application_name</code>.</td>
   </tr>
   <tr>
+    <td><code>organization_id</code></td>
+    <td>GUID identifying the app's organization.</td>
+  </tr>
+  <tr>
     <td><code>space_id</code></td>
     <td>GUID identifying the app's space.</td>
   </tr>
@@ -627,6 +632,7 @@ System-Provided:
   "mem": 256
   },
   "name": "APP-NAME",
+  "organization_id": "c0134bad-97a9-468d-ab9d-e97547e3aed5",
   "space_id": "37189599-2407-9946-865e-8ebd0e2df89a",
   "space_name": "dev",
   "uris": [


### PR DESCRIPTION
The next capi-release (`1.83.0`) will include the organization GUID and organization name for an
app in its VCAP_APPLICATION environment variables.

**See:**
https://github.com/cloudfoundry/cloud_controller_ng/commit/0f9ecb75a1081d64f84d1f3607cbf2050d1a38b1

**CAPI Story:**
[#166547310](https://www.pivotaltracker.com/story/show/166547310)

Co-authored-by: Tim Downey <tdowney@pivotal.io>
Co-authored-by: Mona Mohebbi <mmohebbi@pivotal.io>