### PR TITLE
Fix the expired link for Fluentd Configuration File

### DIFF
--- a/services/fluentd.html.md.erb
+++ b/services/fluentd.html.md.erb
@@ -49,6 +49,6 @@ Fluentd comes with native support for syslog protocol. To set up Fluentd for Clo
 
 <p class="note"><strong>Note</strong>: The Fluentd syslog input plugin supports <code>udp</code> and <code>tcp</code> options. Make sure to use the same transport that Cloud Foundry is using.</p>
 
-Fluentd will start listening for Syslog message on port 5140 and tagging the messages with `cf.app`, which can be used later for data routing. For more details about the full setup for the service, refer to the [Config File](http://docs.fluentd.org/articles/config-file) article.
+Fluentd will start listening for Syslog message on port 5140 and tagging the messages with `cf.app`, which can be used later for data routing. For more details about the full setup for the service, refer to the [Config File](https://docs.fluentd.org/configuration/config-file) article.
 
 If your goal is to use an Elasticsearch or Amazon S3 backend, read the following guide: [http://www.fluentd.org/guides/recipes/elasticsearch-and-s3](http://www.fluentd.org/guides/recipes/elasticsearch-and-s3)


### PR DESCRIPTION
The current link gets you to Page Not Found page.
With this fix, you get to the correct page.