### PR TITLE
Fix _disable_network_policy_enforcement_oss.html.md.erb typo

### DIFF
--- a/deploy-apps/_disable_network_policy_enforcement_oss.html.md.erb
+++ b/deploy-apps/_disable_network_policy_enforcement_oss.html.md.erb
@@ -8,7 +8,7 @@
    $ bosh -e MY-ENV -d MY-DEPLOYMENT manifest > MY-MANIFEST.yml
    </pre>
 
-1. In your BOSH manifest, change the `disable_container_network_policy` value to `false`.
+1. In your BOSH manifest, change the `disable_container_network_policy` value to `true`.
 
 1. Redeploy your app using the edited BOSH manifest:
    <pre class="terminal">


### PR DESCRIPTION
`disable_container_network_policy` needs to be set to true to disable Disable Network Policy Enforcement

See https://bosh.io/jobs/vxlan-policy-agent?source=github.com/cloudfoundry/silk-release&version=2.24.0#p%3ddisable_container_network_policy

> disable_container_network_policy¶
>WARNING!!! Disables network policy enforcement. Setting this property to true allows all app containers to access any other app container with no restrictions.
>Default: false