### PR TITLE
Updated documentation to change v3-app, Issue: #372

### DIFF
--- a/multiple-processes.html.md.erb
+++ b/multiple-processes.html.md.erb
@@ -76,7 +76,7 @@ To view the processes running as part of an app, run `cf APP-NAME`. See the foll
 <p class="note"><strong>Note</strong>: In cf CLI v7, the <code>v3-prefix</code> is not required.</p>
 
 ```
-$ cf v3-app myapp
+$ cf app myapp
  Showing health and status for app myapp in org test / space test as admin...
 
 name: myapp


### PR DESCRIPTION

As per the v3-app commands page, the step
`$ cf v3-app myapp` needs to be changed to `$ cf app myapp`
Issue Raised: https://github.com/cloudfoundry/docs-dev-guide/issues/372