### PR TITLE
Add a note about deleting app ports

### DIFF
--- a/custom-ports.html.md.erb
+++ b/custom-ports.html.md.erb
@@ -99,7 +99,7 @@ To configure your app to receive HTTP or TCP traffic on custom ports:
 
 <div class="note">
 <strong>Note:</strong>
-If you are trying to remove an app port, you will need to delete the associated route mapping before you can update the app to remove the port.  
+If you are trying to remove an app port, you need to delete the associated route mapping before you can update the app to remove the port.  
 </div>
 
 ## <a id="additional-resources"></a> Additional Resources

--- a/custom-ports.html.md.erb
+++ b/custom-ports.html.md.erb
@@ -97,6 +97,10 @@ To configure your app to receive HTTP or TCP traffic on custom ports:
 
 1. Repeat the previous two steps for each port that you want your app to receive requests on. 
 
+<div class="note">
+<strong>Note:</strong>
+If you are trying to remove an app port, you will need to delete the associated route mapping before you can update the app to remove the port.  
+</div>
 
 ## <a id="additional-resources"></a> Additional Resources
 


### PR DESCRIPTION
The steps here don't work if you are trying to remove an app port. You also need to delete the route-mapping before you can remove it from the app.

Let me know if you want all the steps written out too.