### PR TITLE
Fixing rendering typo

### DIFF
--- a/deploy-apps/environment-variable.html.md.erb
+++ b/deploy-apps/environment-variable.html.md.erb
@@ -278,7 +278,7 @@ The table below defines the attributes that describe a bound service. The key fo
 | `plan` | The service plan selected when the service instance was created. |
 | `credentials` | A JSON object containing the service-specific credentials needed to access the service instance. |
 
-To see the value of the `VCAP\_SERVICES` environment variable for an app pushed to <%= vars.app_runtime_abbr %>, see [View Environment Variable Values](#view-env).
+To see the value of the `VCAP_SERVICES` environment variable for an app pushed to <%= vars.app_runtime_abbr %>, see [View Environment Variable Values](#view-env).
 
 The example below shows the value of the `VCAP_SERVICES` environment variable for bound instances of several services available in the Pivotal Web Services Marketplace.
 


### PR DESCRIPTION
Fixing "To see the value of the VCAP\_SERVICES" to "To see the value of the VCAP_SERVICES"