### PR TITLE
Update _using-vol-services.html.md.erb

### DIFF
--- a/services/_using-vol-services.html.md.erb
+++ b/services/_using-vol-services.html.md.erb
@@ -90,8 +90,9 @@ To create and bind an instance for the volume service:
         Where:
         * `YOUR-APP` is the name of the <%= vars.product_name %> app for which you want to use the volume service.
         * `SERVICE-NAME` is the name of the volume service instance you created in the previous step.
-        * `UID` and `GID` are the `uid` and `gid` to use when mounting the share to the app. The `gid` and `uid` must be positive integer values. Provide the `uid` and `gid` as a JSON string in-line or in a file. If you omit `uid` and `gid`, the driver skips `mapfs` mounting and performs just the normal kernel mount of the NFS file system without the overhead associated with FUSE mounts.
+        * (Optional) `UID` and `GID` are the `uid` and `gid` to use when mounting the share to the app. The `gid` and `uid` must be positive integer values. Provide the `uid` and `gid` as a JSON string in-line or in a file. If you omit `uid` and `gid`, the driver skips `mapfs` mounting and performs just the normal kernel mount of the NFS file system without the overhead associated with FUSE mounts.
         <p class="note"><strong>Note:</strong> For security reasons, nfs-volume v2.0.0 and later does not support `uid` and `gid` values of `0`.</p>
+        <p class="note"><strong>Note:</strong> When `uid` and `gid` are omitted, application file operations will use the UID of the running application process. That UID must have access to the files on the share in order for file operations to succeed. In the case of buildpack applications this UID is always `2000`. For Docker applications, the effective UID with be the same as the UID of the process inside the docker container, except for `root` which is mapped to `4294967294` outside the Docker container.</p>
         * (Optional) `OPTIONAL-MOUNT-PATH` is a JSON string that indicates the volume should be mounted to a particular path within your app rather than the default path. Choose a path with a root-level folder that already exists in the container, such as `/home`, `/usr`, or `/var`.
           <p class="note"><strong>Note</strong>: Do not specify a `MOUNT-PATH` within the `/app` directory, which is where <%= vars.product_short %> unpacks the droplet. For more information, see <a href="#mount-path">Mount a Shared Volume in the /app Directory</a>.</p>
         * (Optional) `"readonly":true` is an optional JSON string that creates a read-only mount. By default, Volume Services mounts a read-write file system. For read-only mounts, the driver enables attribute caching. This results in fewer attribute RPCs and better performance.
@@ -333,6 +334,12 @@ As of `nfs-volume-release` v1.3.1, you can specify bind parameters in advance, w
 #### <a id='flock'></a> File Locking with `flock()` and `lockf()`/`fcntl()`
 
 Apps that use file locking through unix system calls such as `flock()` and `fcntl()` or script commands such as `flock` may use the `nfs` service. The `nfs-legacy` service uses a fuse mounting process that does not enforce locks across Diego Cells.
+
+#### Hard links in the NFS service
+
+The mapfs UID mapping layer used by the NFS service does not support hard link operations.  Attempting to create a hard link in an NFS share when `uid` (or `username`) has been specified for the service will fail with a `Function not implemented` error. Workarounds for this issue include:
+* Use symbolic links (`ln -s`) instead of hard links.
+* Omit the `uid` and `gid` (or `username` and `password`) parameters to mount the share without UID mapping. This approach will require the running application user to have access to the files on the share.
 
 
 ## <a id='smb'></a> Create and Use SMB Volume Services


### PR DESCRIPTION
- Include a description of Cloud Foundry file access behavior when UID is not specified in the NFS service.
- Document the limitation that hard links are not supported when UID mapping is enabled in NFS.
[#171841425](https://www.pivotaltracker.com/story/show/171841425)

Note: For PAS/TAS, this change can be back-ported to 2.6-2.9 since it is just documenting a limitation that has existed for a long time.  Let us know if you'd like us to submit separate PRs for those versions.