### PR TITLE
Update docs in preparation for cli V7 GA

### DIFF
--- a/deploy-apps/_v3-note.html.md.erb
+++ b/deploy-apps/_v3-note.html.md.erb
@@ -1,7 +1,7 @@
 <div class="note"><strong>Note</strong>: This attribute is available in the Cloud Foundry V3 API only. To push a manifest that uses this attribute, do either of the following:
   <p>
     <ul>
-      <li>Use cf CLI v7. See <a href="../../cf-cli/v7.html">Upgrading to cf CLI v7 (Beta)</a>.</li>
+      <li>Use cf CLI v7. See <a href="../../cf-cli/v7.html">Upgrading to cf CLI v7</a>.</li>
       <li>Run <code>cf v3-push APP-NAME</code>. See <a href="https://cli.cloudfoundry.org/en-US/cf/v3-push.html">v3-push - Cloud Foundry CLI</a>.</li>
     </ul>
   </p>

--- a/deploy-apps/manifest-attributes.html.md.erb
+++ b/deploy-apps/manifest-attributes.html.md.erb
@@ -3,11 +3,9 @@ title: App Manifest Attribute Reference
 owner: CLI
 ---
 
-This topic describes manifest formatting and provides a full list of attributes available for app manifests using the v6 CLI. You can use it alongside the [Deploying with App Manifests](./manifest.html) topic, which provides basic procedures and guidance for deploying apps with manifests.
+This topic describes manifest formatting and provides a full list of attributes available for app manifests. You can use it alongside the [Deploying with App Manifests](./manifest.html) topic, which provides basic procedures and guidance for deploying apps with manifests.
 
-For manifest properties for the v7 beta cf CLI, see the [CC API documentation](http://v3-apidocs.cloudfoundry.org/version/3.75.0/index.html#app-manifest) for v3 app manifest properties.
-
-
+See the [CC API documentation](http://v3-apidocs.cloudfoundry.org/index.html#space-manifest) for more information on v3 manifest properties.
 
 ## <a id='minimal-manifest'></a> Manifest Format
 

--- a/deploy-apps/rolling-deploy.html.md.erb
+++ b/deploy-apps/rolling-deploy.html.md.erb
@@ -1,21 +1,9 @@
 ---
-title: Rolling App Deployments (Beta)
+title: Rolling App Deployments
 owner: CAPI
 ---
 
-<div class="note">
-<strong>Note:</strong>
-This topic includes references to cf CLI v7 beta commands. Consider the following when using these
-commands:
-<ul>
-  <li>cf CLI v7 beta and CAPI v3 are both in active development and subject to change.</li>
-  <li>cf CLI v7 beta is developed and tested against the latest CAPI release candidate.</li>
-  <li>cf CLI v7 beta does not currently use CAPI v3 for all commands. Some commands still use CAPI v2 during beta.</li>
-</ul>
-For more information, see <a href="../../cf-cli/v7.html">Upgrading to cf CLI v7 (Beta)</a>.
-</div>
-
-This topic describes how developers use beta Cloud Foundry Command Line Interface (cf CLI) commands
+This topic describes how developers use Cloud Foundry Command Line Interface (cf CLI) commands
 or the Cloud Foundry API (CAPI) to push their apps using a rolling deployment.
 
 For information about the traditional method for addressing app downtime while pushing app updates,
@@ -28,8 +16,7 @@ For more information about CAPI, see the
 
 The procedures in this topic require one of the following:
 
-* **cf CLI v7**: If you use cf CLI v7, you must install cf CLI v7. While in beta, cf CLI v7 is only
-    tested against the latest CAPI release candidate.
+* **cf CLI v7**: If you use cf CLI v7, you must install cf CLI v7.
 * **cf CLI v6**: If you use cf CLI v6:
   * You must install cf CLI v6.40 or later.
   * The rolling deployment feature must be enabled for your deployment. <%= vars.zdt_enable %>
@@ -61,7 +48,7 @@ as soon as one instance is healthy.</p>
   1. Run:
 
     ```
-    cf v3-zdt-push APP-NAME
+    cf6 v3-zdt-push APP-NAME
     ```
     Where `APP-NAME` is the name that you want to give your app.
 
@@ -192,7 +179,7 @@ To stop the deployment of an app that you pushed:
   1. Run:
 
     ```
-    cf v3-cancel-zdt-push APP-NAME
+    cf6 v3-cancel-zdt-push APP-NAME
     ```
     Where `APP-NAME` is the name of the app.
 
@@ -234,7 +221,7 @@ configuration updates that require a restart, such as environment variables or s
   1. Run:
 
     ```
-    cf v3-zdt-restart APP-NAME
+    cf6 v3-zdt-restart APP-NAME
     ```
     Where `APP-NAME` is the name of the app.
 
@@ -301,16 +288,16 @@ The following table describes the limitations of when using rolling deployments.
   </tr>
   <tr>
     <td>App Manifests</td>
-    <td>The <code>v3-zdt-push</code> command does not support providing an app manifest with the
+    <td>The <code>cf6 v3-zdt-push</code> command does not support providing an app manifest with the
     <code>-f</code> flag. If you have a <code>manifest.yml</code> file in your app directory, it is
-    ignored. The cf CLI v7 beta does not have this limitation. However, the cf CLI v7 beta does not
-    support multi-app manifests.</td>
+    ignored.</td>
+    <p class="note"><strong>Note:</strong> This limitation only applies to cf CLI v6.</p>
   </tr>
   <tr>
     <td>SSH to app instances</td>
-    <td>Pushing updates to your app with a <code>v3-zdt</code> command causes the new web process
-    and app GUID to mismatch. <code>cf ssh</code> does not handle this scenario. You must use the
-    <code>cf v3-ssh</code> command instead.
+    <td>Pushing updates to your app with a <code>cf6 v3-zdt-push</code> command causes the new web process
+    and app GUID to mismatch. <code>cf6 ssh</code> does not handle this scenario. You must use the
+    <code>cf6 v3-ssh</code> command instead.
     <p class="note"><strong>Note:</strong> This limitation only applies to cf CLI v6.</p>
     </td>
   </tr>

--- a/deploy-apps/routes-domains.html.md.erb
+++ b/deploy-apps/routes-domains.html.md.erb
@@ -7,18 +7,7 @@ owner: Routing
 
 This topic describes how routes and domains work in <%= vars.app_runtime_full %> (<%= vars.app_runtime_abbr %>), and how developers and administrators configure routes and domains for their apps using the Cloud Foundry Command Line Interface (cf CLI).
 
-<div class="note">
-<strong>Note:</strong>
-This topic includes references to cf CLI v7 beta commands. When using these commands, consider:
-<ul>
-<li>cf CLI v7 beta and CAPI v3 are both in active development and subject to change.</li>
-<li>cf CLI v7 beta is developed and tested against the latest CAPI release candidate.</li>
-<li>cf CLI v7 beta does not yet use CAPI v3 for all commands. Some commands still use CAPI v2 during beta.</li>
-</ul>
-For more information, see <a href="../../cf-cli/v7.html">Upgrading to cf CLI v7 (Beta)</a>. 
-</div>
-
-<p class="note"><strong>Note:</strong> cf CLI v7 beta does not support TCP routing. The commands in this topic related to TCP routing only work in cf CLI v6.</p>
+<p class="note"><strong>Note:</strong> cf CLI v7 does not support TCP routing. The commands in this topic related to TCP routing only work in cf CLI v6.</p>
 
 For more information about routing capabilities in <%= vars.app_runtime_abbr %>, see [HTTP Routing](../../concepts/http-routing.html).
 
@@ -250,7 +239,7 @@ If the developer maps the first route with path `products` to the `products` app
 
 #### <a id='create-route-with-port'></a> Create a TCP Route with a Port
 
-<p class="note"><strong>Note:</strong> cf CLI v7 beta does not support TCP routing. The commands in this section related to TCP routing only work in cf CLI v6.</p>
+<p class="note"><strong>Note:</strong> cf CLI v7 does not support TCP routing. The commands in this section related to TCP routing only work in cf CLI v6.</p>
 
 A developer can create a TCP route for `<%= vars.tcp_app_domain %>` on an arbitrary port. If the clients of the app can accommodate addressing an arbitrary port, then developers should use the `--random-port` to instruct <%= vars.app_runtime_abbr %> to pick a port for your route. To create a TCP route for `<%= vars.tcp_app_domain %>` on an arbitrary port, run:
 
@@ -581,7 +570,7 @@ $ cf create-shared-domain <%= vars.app_domain %>
 
 To create a TCP shared domain, first discover the name of the TCP router group.
 
-<p class="note"><strong>Note</strong>: cf CLI v7 beta does not support TCP routing or creating shared domains with router groups.</p>
+<p class="note"><strong>Note</strong>: cf CLI v7 does not support TCP routing or creating shared domains with router groups.</p>
 
 <pre class="terminal">
 $ cf router-groups

--- a/multiple-processes.html.md.erb
+++ b/multiple-processes.html.md.erb
@@ -1,22 +1,9 @@
 ---
-title: Pushing an App with Multiple Processes (Beta)
+title: Pushing an App with Multiple Processes
 owner: CAPI
 ---
 
 This topic describes how to push and manage apps with multiple processes. 
-
-<p class="note"><strong>Note</strong>: This is a beta feature. Because the CLI may change, this feature is not recommended for use in scripts until it is generally available.</p>
-
-<div class="note">
-<strong>Note:</strong>
-This topic includes references to cf CLI v7 beta commands. Consider the following when using these commands:
-<ul>
-<li> cf CLI v7 beta and CAPI v3 are both in active development and subject to change. </li>
-<li> cf CLI v7 beta is developed and tested against the latest CAPI release candidate. </li>
-<li> cf CLI v7 beta does not yet use CAPI v3 for all commands. Some commands still use CAPI v2 during beta. </li>
-</ul>
-For more information, see <a href="../../cf-cli/v7.html">Upgrading to cf CLI v7 (Beta)</a>. 
-</div>
 
 ## <a id="about-processes"></a> About Processes 
 
@@ -29,7 +16,7 @@ For more information about processes, see the <a href="http://v3-apidocs.cloudfo
 You can push an app with multiple processes using a Procfile.
 Follow the procedure below. 
 
-<p class="note"><strong>Note</strong>: You can also push an app with multiple processes using an app manifest. See <a href="https://v3-apidocs.cloudfoundry.org/index.html#the-app-manifest-specification">The app manifest specification</a> in the CAPI v3 docs.</p>
+<p class="note"><strong>Note</strong>: You can also push an app with multiple processes using an app manifest. See the processes section in <a href="https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#-processes">App Manifest Attribute Reference</a>.</p>
 
 
 1. Create a file named `Procfile` in the root of your app directory. 
@@ -49,7 +36,7 @@ Follow the procedure below.
 	* **cf CLI v6**:
 
 		```
-		cf v3-push myapp
+		cf6 v3-push myapp
 		```
 
 By default, the web process has a route and one instance. Other processes have zero instances by default. 
@@ -66,14 +53,12 @@ To scale an app process, run the following command:
 * **cf CLI v6**:
 
 	```
-	cf v3-scale APP-NAME --process PROCESS-NAME -i INSTANCE-COUNT
+	cf6 v3-scale APP-NAME --process PROCESS-NAME -i INSTANCE-COUNT
 	```
 
 ## <a id="view-processes"></a>View Processes
 
-To view the processes running as part of an app, run `cf APP-NAME`. See the following example in which the app has a `web` and a `worker` process. 
-
-<p class="note"><strong>Note</strong>: In cf CLI v7, the <code>v3-prefix</code> is not required.</p>
+To view the processes running as part of an app, run `cf APP-NAME`. See the following example in which the app has a `web` and a `worker` process.
 
 ```
 $ cf app myapp

--- a/push-sub-commands.html.md.erb
+++ b/push-sub-commands.html.md.erb
@@ -1,22 +1,9 @@
 ---
-title: Running cf push Sub-Step Commands (Beta)
+title: Running cf push Sub-Step Commands
 owner: CAPI
 ---
 
-This topic describes how to run beta Cloud Foundry Command Line Interface (cf CLI) commands that provide granular control over the `cf push` process. These commands break down the `cf push` process into sub-steps that can run independently. 
-
-<p class="note"><strong>Note</strong>: This is a beta feature. Because the CLI may change, this feature is not recommended for use in scripts until it is generally available.</p>
-
-<div class="note">
-<strong>Note:</strong>
-This topic includes references to cf CLI v7 beta commands. Consider the following when using these commands:
-<ul>
-<li> cf CLI v7 beta and CAPI v3 are both in active development and subject to change. </li>
-<li> cf CLI v7 beta is developed and tested against the latest CAPI release candidate. </li>
-<li> cf CLI v7 beta does not yet use CAPI v3 for all commands. Some commands still use CAPI v2 during beta. </li>
-</ul>
-For more information, see <a href="../../cf-cli/v7.html">Upgrading to cf CLI v7 (Beta)</a>. 
-</div>
+This topic describes how to run Cloud Foundry Command Line Interface (cf CLI) commands that provide granular control over the `cf push` process. These commands break down the `cf push` process into sub-steps that can run independently.
 
 ## <a id="about"></a> Overview 
 
@@ -46,7 +33,7 @@ For information on using these commands, see the [Example Workflows](#example-wo
 		For more information, see <a href="https://v3-apidocs.cloudfoundry.org/index.html#apps">Apps</a> in the CAPI documentation.</td>
 		<td>
 		<ul>
-			<li><strong>cf CLI v6</strong>: <br><code>cf v3-create-app</code></li>
+			<li><strong>cf CLI v6</strong>: <br><code>cf6 v3-create-app</code></li>
 			<li><strong>cf CLI v7</strong>: <br><code>cf7 create-app</code></li>
 		</ul>
 		</td>
@@ -56,7 +43,7 @@ For information on using these commands, see the [Example Workflows](#example-wo
 		<td>The source code that makes up an app.<br>
 		For more information, see <a href="https://v3-apidocs.cloudfoundry.org/index.html#packages">Packages</a> in the CAPI documentation.</td>
 		<td><ul>
-			<li><strong>cf CLI v6</strong>: <br><code>cf v3-create-package</code></li>
+			<li><strong>cf CLI v6</strong>: <br><code>cf6 v3-create-package</code></li>
 			<li><strong>cf CLI v7</strong>: <br><code>cf7 create-package</code></li>
 		</ul></td>
 	</tr>
@@ -65,26 +52,26 @@ For information on using these commands, see the [Example Workflows](#example-wo
 		<td>The staging process. Creating a build combines a Package with a Buildpack and builds it into an executable resource.<br>
 		For more information, see <a href="https://v3-apidocs.cloudfoundry.org/index.html#builds">Builds</a> in the CAPI documentation.</td>
 		<td><ul>
-			<li><strong>cf CLI v6</strong>: <br><code>cf v3-stage</code></li>
-			<li><strong>cf CLI v7</strong>: <br><code>cf7 stage</code></li>
+			<li><strong>cf CLI v6</strong>: <br><code>cf6 v3-stage</code></li>
+			<li><strong>cf CLI v7</strong>: <br><code>cf7 stage-package</code></li>
 		</ul></td>
 	</tr>
 	<tr>
 		<td>Droplet</td>
 		<td>An executable resource that results from a Build.<br>
-		For more information, see <a href="https://v3-apidocs.cloudfoundry.org/index.html#droplets">Droplet</a>  in the CAPI documentation.</td>
+		For more information, see <a href="https://v3-apidocs.cloudfoundry.org/index.html#droplets">Droplet</a> in the CAPI documentation.</td>
 		<td><ul>
-			<li><strong>cf CLI v6</strong>: <br><code>cf v3-set-droplet</code></li>
+			<li><strong>cf CLI v6</strong>: <br><code>cf6 v3-set-droplet</code></li>
 			<li><strong>cf CLI v7</strong>: <br><code>cf7 set-droplet</code></li>
 		</ul></td>
 	</tr>
 	<tr>
 		<td>Manifest</td>
 		<td>A file used when pushing your app to apply bulk configuration to an app and its underlying processes..<br>
-		For more information, see <a href="https://v3-apidocs.cloudfoundry.org/index.html#app-manifest">App Manifest</a> in the CAPI documentation.</td>
+		For more information, see <a href="https://v3-apidocs.cloudfoundry.org/index.html#space-manifest"> Space Manifest</a> in the CAPI documentation.</td>
 		<td><ul>
-			<li><strong>cf CLI v6</strong>: <br><code>cf v3-create-manifest</code>, code>v3-apply-manifest</code></li>
-			<li><strong>cf CLI v7</strong>: <br><code>cf7 create-manifest</code>, <code>apply-manifest</code></li>
+			<li><strong>cf CLI v6</strong>: <br><code>cf6 v3-apply-manifest</code></li>
+			<li><strong>cf CLI v7</strong>: <br><code>cf7 create-app-manifest</code>, <code>cf7 apply-manifest</code></li>
 		</ul></td>
 	</tr>
 </table>
@@ -106,7 +93,7 @@ This example workflow describes how to push an app using sub-step commands inste
 	* **cf CLI v6**: 
 
 		```
-		cf v3-create-app MY-APP
+		cf6 v3-create-app MY-APP
 		```
 
 1. From your app directory, create a package for your app. 
@@ -118,7 +105,7 @@ This example workflow describes how to push an app using sub-step commands inste
 	* **cf CLI v6**:
 
 		```
-		cf v3-create-package MY-APP
+		cf6 v3-create-package MY-APP
 		```
 
 1. Locate and copy the `package guid` from the output of the previous step. See the following example output:
@@ -132,12 +119,12 @@ This example workflow describes how to push an app using sub-step commands inste
 	* **cf CLI v7**:
 
 		```
-		cf7 stage MY-APP --package-guid PACKAGE-GUID
+		cf7 stage-package MY-APP --package-guid PACKAGE-GUID
 		``` 
 	* **cf CLI v6**:
 
 		```
-		cf v3-stage MY-APP --package-guid PACKAGE-GUID
+		cf6 v3-stage MY-APP --package-guid PACKAGE-GUID
 		``` 
 
 1. Locate and copy the `droplet guid` from the output of the previous step. See the following example output:
@@ -159,7 +146,7 @@ This example workflow describes how to push an app using sub-step commands inste
 	* **cf CLI v6**:
 
 		```
-		cf v3-set-droplet MY-APP -d DROPLET-GUID
+		cf6 v3-set-droplet MY-APP -d DROPLET-GUID
 		```
 
 1. Start your app:
@@ -171,7 +158,7 @@ This example workflow describes how to push an app using sub-step commands inste
 	* **cf CLI v6**:
 
 		```
-		cf v3-start MY-APP
+		cf6 v3-start MY-APP
 		```
 
 ### <a id="update-system-example"></a> Roll Back to a Previous Droplet
@@ -187,7 +174,7 @@ This example workflow describes how to roll back to a previous droplet used by y
 	* **cf CLI v6**:
 
 		```
-		cf v3-droplets MY-APP
+		cf6 v3-droplets MY-APP
 		```
 
 1. From the output, locate and copy the second-to-last GUID. In the following example, this is `66524145-5502-40e6-b782-47fe68e13c49`. 
@@ -208,7 +195,7 @@ This example workflow describes how to roll back to a previous droplet used by y
 	* **cf CLI v6**:
 
 		```
-		cf v3-stop MY-APP
+		cf6 v3-stop MY-APP
 		```
 
 1. Set the app to use the previous droplet:
@@ -220,7 +207,7 @@ This example workflow describes how to roll back to a previous droplet used by y
 	* **cf CLI v6**:
 
 		```
-		cf v3-set-droplet MY-APP -d PREVIOUS-DROPLET-GUID
+		cf6 v3-set-droplet MY-APP -d PREVIOUS-DROPLET-GUID
 		```
 
 1. Start your app:
@@ -232,7 +219,7 @@ This example workflow describes how to roll back to a previous droplet used by y
 	* **cf CLI v6**:
 
 		```
-		cf v3-start MY-APP
+		cf6 v3-start MY-APP
 		```
 
 

--- a/push.html.md.erb
+++ b/push.html.md.erb
@@ -22,7 +22,7 @@ The following topics provide procedures for deploying apps with `cf push`:
 
 * [Pushing an Application with Multiple Buildpacks](../buildpacks/use-multiple-buildpacks.html)
 
-* [Pushing an App with Multiple Processes (Beta)](./multiple-processes.html)
+* [Pushing an App with Multiple Processes](./multiple-processes.html)
 
 * [Running cf push Sub-Step Commands](push-sub-commands.html)
 

--- a/push.html.md.erb
+++ b/push.html.md.erb
@@ -28,7 +28,7 @@ The following topics provide procedures for deploying apps with `cf push`:
 
 * [Rolling App Deployments](./deploy-apps/rolling-deploy.html)
 
-* [Pushing Apps with Sidecar Processes (Alpha)](./sidecars.html)
+* [Pushing Apps with Sidecar Processes](./sidecars.html)
 
 ### <a id="troubleshoot"></a> How to Troubleshoot
 

--- a/push.html.md.erb
+++ b/push.html.md.erb
@@ -24,7 +24,7 @@ The following topics provide procedures for deploying apps with `cf push`:
 
 * [Pushing an App with Multiple Processes (Beta)](./multiple-processes.html)
 
-* [Running cf push Sub-Step Commands (Beta)](push-sub-commands.html)
+* [Running cf push Sub-Step Commands](push-sub-commands.html)
 
 * [Rolling App Deployments](./deploy-apps/rolling-deploy.html)
 

--- a/sidecars.html.md.erb
+++ b/sidecars.html.md.erb
@@ -5,16 +5,6 @@ owner: CAPI
 
 This topic describes sidecar processes and how to include them when you push your app.
 
-<div class="note">
-<strong>Note:</strong> This topic includes references to cf CLI v7 beta commands. When using these commands, consider:
-	<ul>
-		<li>cf CLI v7 beta and CAPI v3 are both in active development and subject to change.</li>
-		<li>cf CLI v7 beta is developed and tested against the latest CAPI release candidate.</li>
-		<li>cf CLI v7 beta does not yet use CAPI v3 for all commands. Some commands still use CAPI v2 during beta.</li>
-	</ul>
-For more information, see <a href="../cf-cli/v7.html">Upgrading to cf CLI v7 (Beta)</a>. 
-</div>
-
 <%= vars.capi_sidecar_req %>
 
 
@@ -122,8 +112,6 @@ Before you can push an app with a sidecar with an app manifest, you must have:
 
 To push an app with a sidecar:
 
-<p class="note"><strong>Note:</strong> This procedure uses <code>v3</code> commands because it requires the server-side manifest support in CAPI v3.</p>
-
 1. Create an app or use an existing app. To create an app:
 	* If you are using cf CLI v7, run:
 
@@ -134,7 +122,7 @@ To push an app with a sidecar:
 	* If you are using cf CLI v6, run:
 
 		```
-		cf v3-create-app APP-NAME
+		cf6 v3-create-app APP-NAME
 		```
 		Where `APP-NAME` is the name you give your app.
 
@@ -179,7 +167,7 @@ To push an app with a sidecar:
 	* If you are using cf CLI v6, run:
 	
 		```
-		cf v3-apply-manifest -f PATH-TO-MANIFEST
+		cf6 v3-apply-manifest -f PATH-TO-MANIFEST
 		```
 		Where `PATH-TO-MANIFEST` is the path to your manifest file.
 
@@ -193,7 +181,7 @@ To push an app with a sidecar:
 	* If you are using cf CLI v6, run:
 
 		```
-		cf v3-push APP-NAME
+		cf6 v3-push APP-NAME
 		```
 		Where `APP-NAME` is the name of your app.
 
@@ -253,7 +241,7 @@ To push the app and sidecar:
 	* If you are using cf CLI v6, run:
 
 		```
-		cf v3-create-app sidecar-dependent-app
+		cf6 v3-create-app sidecar-dependent-app
 		```
 
 1. Navigate to the `sidecar-dependent-app` directory. 
@@ -269,7 +257,7 @@ To push the app and sidecar:
 	* If you are using cf CLI v6, run:
 
 		```
-		cf v3-apply-manifest
+		cf6 v3-apply-manifest
 		```
 
 1. To push the app: 
@@ -281,7 +269,7 @@ To push the app and sidecar:
 	* If you are using cf CLI v6, run:
 	
 		```
-		cf v3-push sidecar-dependent-app
+		cf6 v3-push sidecar-dependent-app
 		```
 
 After you push the app, you can further explore it in [View the Processes Running in the Container](#view-processes) and [View the Web URL and App Logs](#view-logs).


### PR DESCRIPTION
Hi Docs Team. We are preparing to GA cf CLI version 7. We are trying to remove references to any beta tags left behind. This is one of 3 PRs. The others should be in docs-cf-cli, docs-cf-admin.