### PR TITLE
Add note that revisions are experimental

### DIFF
--- a/revisions.html.md.erb
+++ b/revisions.html.md.erb
@@ -9,6 +9,7 @@ For additional information, see [Revisions](http://v3-apidocs.cloudfoundry.org/v
 
 <p class="note"><strong>Note:</strong> CAPI v3 is the recommended API version for revisions. While revisions work with CAPI v2, there are several inconsistencies. For example, revision descriptions for apps with multiple processes may be inaccurate because CAPI v2 does not support apps with multiple processes. Additionally, pushing an app for the first time with revisions in CAPI v2 creates two revisions.</p>
 
+<p class="note"><strong>Note:</strong> The revisions APIs are currently experimental and may have breaking changes in future releases.</p>
 
 ## <a id="overview"></a> Overview
 

--- a/revisions.html.md.erb
+++ b/revisions.html.md.erb
@@ -9,7 +9,7 @@ For additional information, see [Revisions](http://v3-apidocs.cloudfoundry.org/v
 
 <p class="note"><strong>Note:</strong> CAPI v3 is the recommended API version for revisions. While revisions work with CAPI v2, there are several inconsistencies. For example, revision descriptions for apps with multiple processes may be inaccurate because CAPI v2 does not support apps with multiple processes. Additionally, pushing an app for the first time with revisions in CAPI v2 creates two revisions.</p>
 
-<p class="note"><strong>Note:</strong> The revisions APIs are currently experimental and may have breaking changes in future releases.</p>
+<p class="note"><strong>Note:</strong> The App Revisions API is experimental, and future releases may have breaking changes.</p>
 
 ## <a id="overview"></a> Overview
 


### PR DESCRIPTION
There has been some confusion recently because the revisions APIs are experimental, but there isn't any mention in the docs.

Example: https://github.com/cloudfoundry/cloud_controller_ng/issues/2044