### PR TITLE
Add a new section to "Update Service Credentials" without downtime

### DIFF
--- a/services/application-binding.html.md.erb
+++ b/services/application-binding.html.md.erb
@@ -45,7 +45,7 @@ Binding service my-db to app rails-sample in org console / space development as 
 
 ### <a id='bind-with-manifest'></a> Binding with App Manifest ###
 
-As an alternative to binding a service instance after pushing an app, you can use the app manifest to bind the service instance during `cf push`. 
+As an alternative to binding a service instance after pushing an app, you can use the app manifest to bind the service instance during `cf push`.
 
 <p class="note"><strong>Note:</strong> Arbitrary parameters are not supported in app manifests in cf CLI v6.x. Arbitrary parameters are supported in app manifests in cf CLI v7.0 and later.</p>
 
@@ -105,6 +105,7 @@ For details on consuming credentials specific to your development framework, ref
 
 ## <a id='update-credentials'></a>Update Service Credentials
 
+### <a id='update-credentials-with-downtime'></a>With Downtime ###
 To update your service credentials, perform the following steps:
 
   1. [Unbind the service instance](#unbind) using the credentials you are updating with the following command:
@@ -120,6 +121,35 @@ To update your service credentials, perform the following steps:
     </pre>
 
   1. Restart or re-push the app bound to the service instance so that the app recognizes your environment variable updates.
+
+### <a id='update-credentials-without-downtime'></a>Without Downtime ###
+To update your service credentials, perform the following steps:
+
+  1. Start a [blue-green](../deploy-apps/blue-green.html) update of the application.
+
+  1. Execute step 2 in the [blue-green](../deploy-apps/blue-green.html) documentation with the `--no-start` parameter to prevent the application from starting right away.
+
+    <pre class='terminal'>
+    $ cf push YOUR-APP --no-start
+    </pre>
+
+  1. Bind the reguired service instances to the newly deployed `Green` application with the following command.
+
+    <pre class='terminal'>
+    $ cf bind-service YOUR-APP YOUR-SERVICE-INSTANCE
+    </pre>
+
+  1. Start the `Green` applicaiton with `cf start` and continue with the rest of the documentation for [blue-green](../deploy-apps/blue-green.html) updates.
+
+    <pre class='terminal'>
+    $ cf start YOUR-APP
+    </pre>
+
+  1. Unbind the service instances from the `Blue` applicaiton with the following command:
+
+    <pre class='terminal'>
+    $ cf unbind-service YOUR-APP YOUR-SERVICE-INSTANCE
+    </pre>
 
 ## <a id='unbind'></a>Unbind a Service Instance ##
 


### PR DESCRIPTION
The current documentation about [Update Service Credentials](https://docs.cloudfoundry.org/devguide/services/application-binding.html#update-credentials) require
a downtime. Service credentials could be updated without a downtime also.
This commit adds a new section to the [Update Service Credentials](https://docs.cloudfoundry.org/devguide/services/application-binding.html#update-credentials), which describes how to update
service binding credentials without a downtime.

Fixes issue #426 