### PR TITLE
Remove stray backtick

### DIFF
--- a/deploy-apps/ssh-apps.html.md.erb
+++ b/deploy-apps/ssh-apps.html.md.erb
@@ -181,7 +181,7 @@ E1x89n
   <br>
   <br>
   Or you can use `ssh` piped with `cat` command to transfer file by running:
-  * `cat local_file_path | cf ssh MY-AWESOME-APP -c "cat > remote_file_path"``
+  * `cat local_file_path | cf ssh MY-AWESOME-APP -c "cat > remote_file_path"`
 
 1. When the SSH proxy reports its RSA fingerprint, confirm that it matches the `app_ssh_host_key_fingerprint` recorded above. When prompted for a password, paste in the authorization code returned by `cf ssh-code`.
 <pre class="terminal">


### PR DESCRIPTION
There is an unintentional double backtick here. This can be seen in the published documentation e.g. 
![Screenshot 2021-08-04 at 14 27 54](https://user-images.githubusercontent.com/1764158/128189157-8ccccb0e-52c6-48e4-bb01-bc251b84b896.png)
