### PR TITLE
Adds a note for private container credentials change and rotation

### DIFF
--- a/deploy-apps/push-docker.html.md.erb
+++ b/deploy-apps/push-docker.html.md.erb
@@ -160,6 +160,8 @@ Where:
 
 * `USER` is the username to use for authentication with the registry.
 
+<p class="note"><strong>Note:</strong> If container registry credentials change the application have to be pushed with the new credentials. Otherwise Cloud Foundry will fail to start the application because during start access to the container registry is required. For container credentials rotation we recommend a set of two credentials (old/new) where the <code>old</code> credentials can be deactivated after all application have been pushed with the <code>new</code> credentials.</p>
+
 ### <a id='ecr'></a> Amazon Elastic Container Registry (ECR)
 
 <%= vars.app_runtime_abbr %> supports pushing apps from images hosted on Amazon Web Services ECR, which authenticates with temporary password tokens.


### PR DESCRIPTION
A change of the credentials used to push a docker based application
requires a re-push of the application with the new credentials.
Ohterwise CF wan't be able to start this application because during start access
to the container registry is required. A start could be triggered
because of different reasons (an appliation crash or application evacuation, etc.).