### PR TITLE
update client library references

### DIFF
--- a/capi/client-libraries.html.md.erb
+++ b/capi/client-libraries.html.md.erb
@@ -35,9 +35,6 @@ CF does not support the following clients, but they may be supported by third-pa
 
 * Golang
    * [cloudfoundry-community/go-cfclient](https://github.com/cloudfoundry-community/go-cfclient)
-   * [guidowb/cf-go-client](https://github.com/guidowb/cf-go-client)
-* Node.js
-   * [prosociallearnEU/cf-nodejs-client](https://github.com/prosociallearnEU/cf-nodejs-client)
 * Python: 
    * [hsdp/python-cf-api](https://github.com/hsdp/python-cf-api)
    * [cloudfoundry-community/cf-python-client](https://github.com/cloudfoundry-community/cf-python-client)

--- a/capi/client-libraries.html.md.erb
+++ b/capi/client-libraries.html.md.erb
@@ -36,5 +36,5 @@ CF does not support the following clients, but they may be supported by third-pa
 * Golang
    * [cloudfoundry-community/go-cfclient](https://github.com/cloudfoundry-community/go-cfclient)
 * Python: 
-   * [hsdp/python-cf-api](https://github.com/hsdp/python-cf-api)
    * [cloudfoundry-community/cf-python-client](https://github.com/cloudfoundry-community/cf-python-client)
+   * [hsdp/python-cf-api](https://github.com/hsdp/python-cf-api)

--- a/capi/client-libraries.html.md.erb
+++ b/capi/client-libraries.html.md.erb
@@ -33,9 +33,11 @@ The following client is experimental and a work in progress:
 
 CF does not support the following clients, but they may be supported by third-parties:
 
-* [Golang](https://github.com/guidowb/cf-go-client)
-* [Golang](https://github.com/cloudfoundry-community/go-cfclient)
-* [Node.js](https://github.com/prosociallearnEU/cf-nodejs-client)
+* Golang
+   * [cloudfoundry-community/go-cfclient](https://github.com/cloudfoundry-community/go-cfclient)
+   * [guidowb/cf-go-client](https://github.com/guidowb/cf-go-client)
+* Node.js
+   * [prosociallearnEU/cf-nodejs-client](https://github.com/prosociallearnEU/cf-nodejs-client)
 * Python: 
    * [hsdp/python-cf-api](https://github.com/hsdp/python-cf-api)
    * [cloudfoundry-community/cf-python-client](https://github.com/cloudfoundry-community/cf-python-client)


### PR DESCRIPTION
- Standardize format for links to external client libraries
- Remove links to abandoned client library projects
- Reorder python libraries to promote cloudfoundry-community repos first
