### PR TITLE
Remove references to cf-drain-cli plugin

### DIFF
--- a/services/log-management.html.md.erb
+++ b/services/log-management.html.md.erb
@@ -32,8 +32,6 @@ For more information about service instance lifecycle management, see [Managing 
 
 If a compatible log management service is not available in your Cloud Foundry marketplace, you can use user-provided service instances to stream app logs to a service of your choice. For more information, see the [Stream App Logs to a Service](./user-provided.html#syslog) section of the _User-Provided Service Instances_ topic.
 
-You can install and use the [CF Drain CLI Plugin](#drain-plugin) to create and manage user-provided syslog drains from the CF command-line interface (cf CLI).
-
 You may need to prepare your log management service to receive app logs from Cloud Foundry. For specific instructions for several popular services, see [Service-Specific Instructions for Streaming App Logs](./log-management-thirdparty-svc.html). If you cannot find instructions for your service, follow the generic instructions below.
 
 ### <a id='step1'></a>Step 1: Configure the Log Management Service
@@ -58,40 +56,7 @@ To set up a communication channel between the log management service and your Cl
 
 ### <a id='step2'></a> Step 2: Create and Bind a User-Provided Service Instance
 
-You can create a syslog drain service and bind apps to it using either generic Cloud Foundry Command Line Interface (cf CLI) commands, or drain-specific commands enabled by the CF Drain plugin for the cf CLI.
-
-Each option is described below.
-
-#### <a id='drain-plugin'></a> With the CF Drain CLI Plugin
-
-1. If the CF Drain CLI Plugin is not installed on your local workstation, follow the [Installing Plugin](https://github.com/cloudfoundry/cf-drain-cli#installing-plugin) instructions in the plugin source repository on GitHub.
-
-2. Decide whether to bind the drain to a single app or all apps in a space, and run the corresponding command:
-  * **Single app**:<br>
-
-        ```
-        cf drain APP-NAME SYSLOG-DRAIN-URL
-        ```
-        Where:
-        * `APP-NAME` is name of the app from which to stream logs.
-        * `SYSLOG-DRAIN-URL` is the syslog URL from [Step 1: Configure the Log Management Service](#step1).
-  * **All apps in a space**:
-
-        ```
-        cf drain-space --drain-name DRAIN-NAME --drain-url SYSLOG-DRAIN-URL --username USERNAME
-        ```
-        Where:
-        * `DRAIN-NAME` is the name of the app from which to stream logs.
-        * `SYSLOG-DRAIN-URL` is the syslog URL from [Step 1: Configure the Log Management Service](#step1).
-        * `USERNAME` is the username to use when pushing the app. If you do not specify a username, you must have admin permissions because the plugin will create a user.
-
-After a short delay, logs begin to flow automatically.
-
-For CF Drain commands, see the [Usage](https://github.com/cloudfoundry/cf-drain-cli#installing-plugin) section of the CF Drain plugin source repository on GitHub. For general CF service commands, see [Managing Service Instances with the CLI](./managing-services.html).
-
-#### <a id='no-plugin'></a> With General cf CLI Service Commands
-
-<p class="note"><strong>Note:</strong> To bind a drain to all apps in a space with a single command, you must use the CF Drain CLI Plugin as described in the previous section.</p>
+You can create a syslog drain service and bind apps to it using Cloud Foundry Command Line Interface (cf CLI) commands.
 
 1. To create the service instance, run `cf create-user-provided-service` (or `cf cups`) with the `-l` flag, filling in values as follows:
   - DRAIN-NAME: A name to use for your syslog drain service instance.
@@ -123,11 +88,3 @@ To verify that logs are draining correctly to a third-party log management servi
 For example, if your app serves web pages, you can send HTTP requests to the app. In Cloud Foundry, these generate Router log messages, which you can view in the CLI. Your third-party log management service should display corresponding messages.
 
 <p class="note"><strong>Note:</strong> For security reasons, Cloud Foundry apps do not respond to <code>ping</code>. You cannot use <code>ping</code> to generate log entries.</p>
-
-### <a id='drain-cli'></a> CF Drain CLI Plugin
-
-The CF Drain CLI plugin extends the cf CLI by adding simple commands for user-provided syslog drains. You can also use the plugin to bind all apps in a space to a syslog drain. This option includes app, space, and org names in the drain. It also binds any new apps pushed to the space.
-
-**Installation**: To install the CF Drain CLI plugin, see the [Installing Plugin](https://github.com/cloudfoundry/cf-drain-cli#installing-plugin) instructions in the plugin source repository on GitHub.
-
-**Commands**: The plugin adds commands for creating, deleting, and listing syslog drains, and for binding apps to the drains. For more information, see the [Usage](https://github.com/cloudfoundry/cf-drain-cli#installing-plugin) section of the plugin source repository on GitHub.


### PR DESCRIPTION
Deprecating cf-drain-cli plugin in favor of the generic CLI commands.

cc @mkocher 