### PR TITLE
Improve documentation around User Provided Instance Update

### DIFF
--- a/services/application-binding.html.md.erb
+++ b/services/application-binding.html.md.erb
@@ -118,6 +118,8 @@ This section describes how to update service instance credentials.
 When updating the credentials, you can restage the app immediately and experience app downtime.
 If your app uses blue-green deployment, you can update service instance credentials with no downtime.
 
+<p class='note'><strong>Note</strong>: For user-provided services please check the <a href="https://docs.cloudfoundry.org/devguide/services/user-provided.html#update">Update a User-provided Service Instance</a></p>
+
 ### <a id='update-credentials-with-downtime'></a>With Downtime
 
 To update your service credentials:

--- a/services/user-provided.html.md.erb
+++ b/services/user-provided.html.md.erb
@@ -78,4 +78,7 @@ For more information, see [Managing App Requests with Route Services](./route-bi
 
 You can use [cf update-user-provided-service](http://cli.cloudfoundry.org/en-US/cf/update-user-provided-service.html) to update the attributes of an instance of a user-provided service. New credentials overwrite old credentials, and parameters not provided are deleted.
 
-The alias for `update-user-provided-service` is `uups`.
+The alias for `update-user-provided-service` is `uups`. Bound applications can access the new configuration after restart. The restart can be executed with the [rolling strategy](https://docs.cloudfoundry.org/devguide/deploy-apps/rolling-deploy.html#restart) to avoid any downtimes.
+<p class="note">
+<strong>Note</strong>: In case of credentials the old credentials must be active until the restart is finished.
+</p>


### PR DESCRIPTION
This pr tries to improve the documentation for User Provided Instance Update. There are two things:

- adds a note to make sure that UPS instances can be updated more easily
- explains how the updated configuration/credentials of an UPS instance can be consumed

