### PR TITLE
Do not use env vars for credentials

### DIFF
--- a/deploy-apps/environment-variable.html.md.erb
+++ b/deploy-apps/environment-variable.html.md.erb
@@ -14,6 +14,7 @@ Environment variables are the means by which <%= vars.app_runtime_abbr %> commun
 
 For information about setting your own app-specific environment variables, see the [Environment Variable](./manifest.html#env-block) section of the _Deploying with App Manifests_ topic.
 
+<p class="note"><strong>Note</strong>: Do not use user-provided environment variables for security sensitive information like credentials as they may unintentionally show up in cf cli output and Cloud Controller logs. Use [user-provided service instances](../services/user-provided.html) instead. The system-provided environment variable [VCAP_SERVICES](#VCAP_SERVICES) is properly redacted for user roles like Space Supporter and in Cloud Controller log files.</p>
 
 ## <a id='view-env'></a> View Environment Variables
 

--- a/deploy-apps/manifest-attributes.html.md.erb
+++ b/deploy-apps/manifest-attributes.html.md.erb
@@ -43,8 +43,6 @@ If not specified, the `versions` property defaults to `1`.
 
 You can use variables to create app manifests with values shared across all applicable environments in combination with references to environment-specific differences defined in separate files.
 
-In addition, using variables enables you to store sensitive data in a separate file that the app manifest would reference, making the security sensitive data easier to manage and keep secure.
-
 To add variables to an app manifest, do the following:
 
 1. Create a file called `vars.yml`.
@@ -536,6 +534,7 @@ For example:
 
 <p class="note"><strong>Note</strong>: You must name variables with alphanumeric characters and underscores. Non-conforming variable names may cause unpredictable behavior.</p>
 
+<p class="note"><strong>Note</strong>: Do not use user-provided environment variables for security sensitive information like credentials as they may unintentionally show up in cf cli output and Cloud Controller logs. Use [user-provided service instances](../services/user-provided.html) instead. The system-provided environment variable [VCAP_SERVICES](#VCAP_SERVICES) is properly redacted for user roles like Space Supporter and in Cloud Controller log files.</p>
 
 While the app is running, you can modify environment variables.
 


### PR DESCRIPTION
Add a note to use user-provided service instances instead.
User-provided env vars show up in cf cli (manifest diff) and CC logs.

Removed the sentence to use manifest  variables to hide
security sensitive values. They are printed by cf cli v8 (manifest diff) and
the only real use case would be env vars.