### PR TITLE
update fluentd docs to be correct

### DIFF
--- a/services/fluentd.html.md.erb
+++ b/services/fluentd.html.md.erb
@@ -30,7 +30,7 @@ For example:
 ## <a id='config'></a>Step 2: Set up Fluentd for Cloud Foundry ##
 
 This section assumes you have an active Fluentd instance running. If you do not have an active Fluentd instance, refer to the [Fluentd Documentation/Install]
-(http://docs.fluentd.org/categories/installation) steps for more details.
+(http://docs.fluentd.org/categories/installation) steps for more details. If you use cf to deploy your fluentd instances, you will have to use [tcp routing](../deploy-apps/routes-domains#create-route-with-port).
 
 Fluentd comes with native support for syslog protocol. To set up Fluentd for Cloud Foundry, configure the syslog input of Fluentd as follows.
 
@@ -39,16 +39,22 @@ Fluentd comes with native support for syslog protocol. To set up Fluentd for Clo
 	```
 	<source>
 	  @type syslog
-	  port 5140
+	  port 8080
 	  bind 0.0.0.0
 	  tag cf.app
-	  protocol_type udp
+	  message_length_limit 99990
+	  frame_type octet_count
+	  <transport tcp>
+	  </transport>
+	  <parse>
+		message_format rfc5424
+	  </parse>
 	</source>
 	```
 1. Restart the Fluentd service.
 
-<p class="note"><strong>Note</strong>: The Fluentd syslog input plugin supports <code>udp</code> and <code>tcp</code> options. Make sure to use the same transport that Cloud Foundry is using.</p>
+<p class="note"><strong>Note</strong>: The Fluentd syslog input plugin supports <code>tls</code> and <code>tcp</code> options. Make sure to use the same transport that Cloud Foundry is using.</p>
 
-Fluentd will start listening for Syslog message on port 5140 and tagging the messages with `cf.app`, which can be used later for data routing. For more details about the full setup for the service, refer to the [Config File](https://docs.fluentd.org/configuration/config-file) article.
+Fluentd will start listening for Syslog message on port 8080 and tagging the messages with `cf.app`, which can be used later for data routing. For more details about the full setup for the service, refer to the [Config File](https://docs.fluentd.org/configuration/config-file) article.
 
 If your goal is to use an Elasticsearch or Amazon S3 backend, read the following guide: [http://www.fluentd.org/guides/recipes/elasticsearch-and-s3](http://www.fluentd.org/guides/recipes/elasticsearch-and-s3)


### PR DESCRIPTION
- update frame_type to handle app logs correctly
- remove udp, has never been supported with syslog agents
- added parsing for rfc5424
- changed port to 8080 to better represent the common usecase of cf pushed fluentd
- added note about tcp routing