### PR TITLE
Add sample HTTP/2 and gRPC applications

### DIFF
--- a/http2-protocol.html.md.erb
+++ b/http2-protocol.html.md.erb
@@ -201,3 +201,24 @@ See [Push an App with End-to-End HTTP/2 Using the App Manifest](#e2e-manifest) o
 	  "body": "Hello"
 	}
 	```
+
+## <a id="sample-apps"></a> Sample Applications
+
+Below are some sample HTTP/2 and gRPC applications from the community. They can
+be used to experiment with HTTP/2 and provide code examples for different
+languages and frameworks.
+
+- [ASP.NET Core HTTP/2 App](https://github.com/Gerg/dotnet_http2)
+- [Golang CATs gRPC App](https://github.com/cloudfoundry/cf-acceptance-tests/tree/main/assets/grcp)
+- [Golang CATs HTTP/2 App](https://github.com/cloudfoundry/cf-acceptance-tests/tree/main/assets/http2)
+- [Golang HTTP/2 Tile App](https://github.com/Gerg/http2_tile_demo)
+- [Golang SAP gRPC App](https://github.com/SAP-samples/cf-routing-samples/tree/main/http2/go-grpc)
+- [Golang SAP HTTP/2 App](https://github.com/SAP-samples/cf-routing-samples/tree/main/http2/go-http2)
+- [Java SAP gRPC App](https://github.com/SAP-samples/cf-routing-samples/tree/main/http2/java-grpc)
+- [Java SAP HTTP/2 App](https://github.com/SAP-samples/cf-routing-samples/tree/main/http2/java-http2)
+- [Node SAP gRPC App](https://github.com/SAP-samples/cf-routing-samples/tree/main/http2/node-grpc)
+- [Node SAP HTTP/2 App](https://github.com/SAP-samples/cf-routing-samples/tree/main/http2/node-http2)
+- [Python SAP gRPC App](https://github.com/SAP-samples/cf-routing-samples/tree/main/http2/python-grpc)
+- [Python SAP HTTP/2 App](https://github.com/SAP-samples/cf-routing-samples/tree/main/http2/python-http2)
+- [Ruby SAP gRPC App](https://github.com/SAP-samples/cf-routing-samples/tree/main/http2/ruby-grpc)
+- [Ruby SAP HTTP/2 App](https://github.com/SAP-samples/cf-routing-samples/tree/main/http2/ruby-http2)


### PR DESCRIPTION
Add a list of sample HTTP/2 and gRPC applications to the HTTP/2 application developer docs. This was partially inspired because getting HTTP/2 working on CF can be a bit tricky for some languages/frameworks (looking at you ASP.NET 😠).