### PR TITLE
Add the mTLS syslog drain feature to the documentation

### DIFF
--- a/services/log-management.html.md.erb
+++ b/services/log-management.html.md.erb
@@ -66,7 +66,6 @@ You can create a syslog drain service and bind apps to it using Cloud Foundry Co
 <pre class="terminal">
 $ cf create-user-provided-service DRAIN-NAME -l SYSLOG-URL
 </pre>
-
 In case of the usage of the mTLS feature delivered in [CAPI release 1.141.0](https://github.com/cloudfoundry/capi-release/releases/tag/1.141.0), you can use `-p` flag to define the credentials, filling in values as follows.
 <pre class="terminal">
 $ cf create-user-provided-service DRAIN-NAME -l SYSLOG-URL -p {"cert":"-----BEGIN CERTIFICATE-----\nMIIH...-----END CERTIFICATE-----","key":"-----BEGIN PRIVATE KEY-----\nMIIE...-----END PRIVATE KEY-----"}

--- a/services/log-management.html.md.erb
+++ b/services/log-management.html.md.erb
@@ -11,7 +11,7 @@ Cloud Foundry aggregates logs for all instances of your apps as well as for requ
 
 If you want to persist more than the limited amount of logging information that Cloud Foundry can buffer, drain these logs to a log management service.
 
-<b>Feature:</b>  Since [CAPI release 1.141.0](https://github.com/cloudfoundry/capi-release/releases/tag/1.141.0) you've got also the opportunity to used mTLS inside your syslog drain. Please, follow the described process inside <a href="#step2">Step 2: Create and Bind a User-Provided Service Instance</a> to handle it and inject the corresponding credentials as <em>PEM</em> encoded <em>X.509</em> certificate.
+<b>Feature:</b>  Since [CAPI release 1.141.0](https://github.com/cloudfoundry/capi-release/releases/tag/1.141.0) you can use mTLS inside your syslog drain. Please, follow the described process inside <a href="#step2">Step 2: Create and Bind a User-Provided Service Instance</a> to handle it. Please inject the corresponding credentials as <em>PEM</em> encoded <em>X.509</em> certificate.
 
 For more information about the systems responsible for log aggregation and streaming in Cloud Foundry, see [App Logging in Cloud Foundry](../deploy-apps/streaming-logs.html).
 
@@ -60,13 +60,14 @@ To set up a communication channel between the log management service and your Cl
 
 You can create a syslog drain service and bind apps to it using Cloud Foundry Command Line Interface (cf CLI) commands.
 
-1. To create the service instance, run `cf create-user-provided-service` (or `cf cups`) with the `-l` and in case of the usage of the new mTLS feature delivered in [CAPI release 1.141.0](https://github.com/cloudfoundry/capi-release/releases/tag/1.141.0), you case use `-p` flag to define the credentials, filling in values as follows:
+1. To create the service instance, run `cf create-user-provided-service` (or `cf cups`) with the `-l`.
   - DRAIN-NAME: A name to use for your syslog drain service instance.
   - SYSLOG-DRAIN-URL: The syslog URL from [Step 1: Configure the Log Management Service](#step1).
 <pre class="terminal">
 $ cf create-user-provided-service DRAIN-NAME -l SYSLOG-URL
 </pre>
-In case of the usage of mTLS, please use the following commands:
+
+In case of the usage of the mTLS feature delivered in [CAPI release 1.141.0](https://github.com/cloudfoundry/capi-release/releases/tag/1.141.0), you can use `-p` flag to define the credentials, filling in values as follows.
 <pre class="terminal">
 $ cf create-user-provided-service DRAIN-NAME -l SYSLOG-URL -p {"cert":"-----BEGIN CERTIFICATE-----\nMIIH...-----END CERTIFICATE-----","key":"-----BEGIN PRIVATE KEY-----\nMIIE...-----END PRIVATE KEY-----"}
 </pre>

--- a/services/log-management.html.md.erb
+++ b/services/log-management.html.md.erb
@@ -11,6 +11,8 @@ Cloud Foundry aggregates logs for all instances of your apps as well as for requ
 
 If you want to persist more than the limited amount of logging information that Cloud Foundry can buffer, drain these logs to a log management service.
 
+<b>Feature:</b>  Since [CAPI release 1.141.0](https://github.com/cloudfoundry/capi-release/releases/tag/1.141.0) you've got also the opportunity to used mTLS inside your syslog drain. Please, follow the described process inside <a href="#step2">Step 2: Create and Bind a User-Provided Service Instance</a> to handle it and inject the corresponding credentials as <em>PEM</em> encoded <em>X.509</em> certificate.
+
 For more information about the systems responsible for log aggregation and streaming in Cloud Foundry, see [App Logging in Cloud Foundry](../deploy-apps/streaming-logs.html).
 
 
@@ -58,12 +60,17 @@ To set up a communication channel between the log management service and your Cl
 
 You can create a syslog drain service and bind apps to it using Cloud Foundry Command Line Interface (cf CLI) commands.
 
-1. To create the service instance, run `cf create-user-provided-service` (or `cf cups`) with the `-l` flag, filling in values as follows:
+1. To create the service instance, run `cf create-user-provided-service` (or `cf cups`) with the `-l` and in case of the usage of the new mTLS feature delivered in [CAPI release 1.141.0](https://github.com/cloudfoundry/capi-release/releases/tag/1.141.0), you case use `-p` flag to define the credentials, filling in values as follows:
   - DRAIN-NAME: A name to use for your syslog drain service instance.
   - SYSLOG-DRAIN-URL: The syslog URL from [Step 1: Configure the Log Management Service](#step1).
 <pre class="terminal">
 $ cf create-user-provided-service DRAIN-NAME -l SYSLOG-URL
 </pre>
+In case of the usage of mTLS, please use the following commands:
+<pre class="terminal">
+$ cf create-user-provided-service DRAIN-NAME -l SYSLOG-URL -p {"cert":"-----BEGIN CERTIFICATE-----\nMIIH...-----END CERTIFICATE-----","key":"-----BEGIN PRIVATE KEY-----\nMIIE...-----END PRIVATE KEY-----"}
+</pre>
+
 For more information, see [User-Provided Service Instances](./user-provided.html).
 
 1. To bind an app to the service instance, do one of the following:


### PR DESCRIPTION
Hello everyone,

with this PR, I've added the documentation of the mTLS feature of the Syslog drain functionality rolled out inside the Cloud Controller [here](https://github.com/cloudfoundry/cloud_controller_ng/pull/3028) and inside the Loggreagator Agent Release [here](https://github.com/cloudfoundry/loggregator-agent-release/pull/119). 

The corresponding PR describes, how to inject the corresponding certs inside the user-provided service and establish a Syslog connection over mTLS.

The corresponding part for the Loggregator Release is currently in state `under review`, but we've already prepared the Community documentation for the usage of the feature.