### PR TITLE
2 fixes for health-check-invocation-timeout

### DIFF
--- a/deploy-apps/manifest-attributes.html.md.erb
+++ b/deploy-apps/manifest-attributes.html.md.erb
@@ -271,6 +271,7 @@ For example:
 ### <a id='health-check-invocation-timeout'></a> health-check-invocation-timeout
 
 The `health-check-invocation-timeout` attribute configures the timeout in seconds for individual health check requests for HTTP and port health checks.
+The  attribute defaults to 1.
 
 For example:
 
@@ -282,7 +283,7 @@ For example:
 
 To override this attribute, run `cf set-health-check APP-NAME http --invocation-timeout 10`, where `APP-NAME` is the name of your app.
 
-Within the manifest, the health check timeout is controlled by the `timeout` attribute.
+Within the manifest, the health check timeout is controlled by the `health-check-invocation-timeout` attribute.
 
 ### <a id='health-check-type'></a> health-check-type
 


### PR DESCRIPTION
* default value noted
* wrong reference to `timeout` removed (a related, but different timeout)

===

I'm 90% sure these fixes are indeed fixes, and I'm submitting this PR in part to get some validation that my understanding is indeed correct.

* the default value was deduced from error messages in my running cells, i.e. `Instance became unhealthy: Failed to make HTTP request to '/healthcheck' on port 8080: timed out after 1.00 seconds`
* I'm reasonably sure that the typo-fix is indeed a fix, but I cannot look into the head of the person that originally wrote this down.