### PR TITLE
Container metrics forwarding with syslog drains

### DIFF
--- a/deploy-apps/streaming-logs.html.md.erb
+++ b/deploy-apps/streaming-logs.html.md.erb
@@ -158,13 +158,7 @@ delivering the message to Loggregator.
 Alternatively, you can write log messages to `stderr` or `stdout` synchronously. This approach is mainly used for
 debugging because it might affect app performance.
 
-## <a id='container-metrics'></a> Including container metrics in syslog drains
-
-By default, app logs are included in syslog drains. Syslog Agents forward logs to configured syslog drains and Loggregator. For more information about Syslog
-Agents, see [Loggregator Architecture and Components](../../loggregator/architecture.html#components) in _Loggregator Architecture_.
-
-
-## <a id='view'></a> Viewing logs
+## <a id='view'></a> Viewing Logs
 
 To view logs, run the `cf logs` command. You can tail, dump, or filter log output. For more information about the  `cf logs` command, see the [Cloud Foundry
 CLI Reference Guide](https://cli.cloudfoundry.org/en-US/cf/logs.html).

--- a/services/log-management.html.md.erb
+++ b/services/log-management.html.md.erb
@@ -70,7 +70,7 @@ You can create a syslog drain service and bind apps to it using Cloud Foundry Co
       <li><code>SYSLOG-DRAIN-URL</code> is the syslog URL from <a href="#step1">Step 1: Configure the Log Management Service</a>.</li>
     </ul>
 
-    By default, the Syslog Agent would forward only applicaton logs to a Syslog server. If one wants to have the application [container metrics](../../loggregator/container-metrics.html) like CPU, memory or disk usage forwarded as well, one can use the `drain-type` parameter to specify if only logs, container metrics or both should be forwarded by the syslog drain. The `drain-type` parameter should be added to the `SYSLOG-DRAIN-URL`.
+    By default, the Syslog Agent would forward only applicaton logs to a Syslog server. If one wants to have the application [container metrics](../../loggregator/container-metrics.html) like CPU, memory, or disk usage forwarded as well, one can use the `drain-type` parameter to specify if only logs, container metrics or both should be forwarded by the syslog drain. The `drain-type` parameter should be added to the `SYSLOG-DRAIN-URL`.
 
     <pre class="terminal">
     $ cf create-user-provided-service DRAIN-NAME -l SYSLOG-URL?drain-type=DRAIN_TYPE_VALUE
@@ -78,12 +78,12 @@ You can create a syslog drain service and bind apps to it using Cloud Foundry Co
 
     Where `DRAIN_TYPE_VALUE` should be one of the following:
     <ul>
-        <li><code>logs</code> forward logs only (this is also the default when the parameter is not present).</li>
-        <li><code>metrics</code> forward container metrics only.</li>
-        <li><code>all</code> forward both logs and metrics.</li>
+        <li><code>logs</code> forwards logs only (this is also the default when the parameter is not present).</li>
+        <li><code>metrics</code> forwards container metrics only.</li>
+        <li><code>all</code> forwards both logs and metrics.</li>
     </ul>
 
-    Example, foreward application logs and container metrics:
+    Example, forward application logs and container metrics:
     <pre class="terminal">
     $ cf create-user-provided-service my_app_drain -l syslog://logs.example.com:1234?drain-type=all
     </pre>

--- a/services/log-management.html.md.erb
+++ b/services/log-management.html.md.erb
@@ -70,6 +70,24 @@ You can create a syslog drain service and bind apps to it using Cloud Foundry Co
       <li><code>SYSLOG-DRAIN-URL</code> is the syslog URL from <a href="#step1">Step 1: Configure the Log Management Service</a>.</li>
     </ul>
 
+    By default, the Syslog Agent would forward only applicaton logs to a Syslog server. If one wants to have the application [container metrics](../../loggregator/container-metrics.html) like CPU, memory or disk usage forwarded as well, one can use the `drain-type` parameter to specify if only logs, container metrics or both should be forwarded by the syslog drain. The `drain-type` parameter should be added to the `SYSLOG-DRAIN-URL`.
+
+    <pre class="terminal">
+    $ cf create-user-provided-service DRAIN-NAME -l SYSLOG-URL?drain-type=DRAIN_TYPE_VALUE
+    </pre>
+
+    Where `DRAIN_TYPE_VALUE` should be one of the following:
+    <ul>
+        <li><code>logs</code> forward logs only (this is also the default when the parameter is not present).</li>
+        <li><code>metrics</code> forward container metrics only.</li>
+        <li><code>all</code> forward both logs and metrics.</li>
+    </ul>
+
+    Example, foreward application logs and container metrics:
+    <pre class="terminal">
+    $ cf create-user-provided-service my_app_drain -l syslog://logs.example.com:1234?drain-type=all
+    </pre>
+
 In case of the usage of the mTLS feature delivered in [CAPI release 1.143.0](https://github.com/cloudfoundry/capi-release/releases/tag/1.143.0), you can use `-p` flag to define the client certificate and key as credentials, filling in values as follows.
 <pre class="terminal">
 $ cf create-user-provided-service DRAIN-NAME -l SYSLOG-URL -p '{"cert":"-----BEGIN CERTIFICATE-----\nMIIH...-----END CERTIFICATE-----","key":"-----BEGIN PRIVATE KEY-----\nMIIE...-----END PRIVATE KEY-----"}'


### PR DESCRIPTION
- Add documentation for configuring syslog drains to forward container metrics
- Remove old deprecated documentation