### PR TITLE
Add missing tag

### DIFF
--- a/deploy-apps/routes-domains.html.md.erb
+++ b/deploy-apps/routes-domains.html.md.erb
@@ -353,7 +353,7 @@ Destinations:
 
 Developers can only view a route within a space where they are a member.
 
-class="note important">
+<p class="note important">
 <span class="note__title">Important</span>
 The <code>cf route</code> command is available in cf CLI v8 only.</p>
 


### PR DESCRIPTION
Formatting is currently partly broken on this page, I assume due to this missing tag...

<img width="702" alt="Screenshot 2023-09-15 at 16 25 22" src="https://github.com/cloudfoundry/docs-dev-guide/assets/783230/530f2511-52df-41a7-ae42-86cfc6af68c8">