### PR TITLE
Update CF env var size limit

### DIFF
--- a/deploy-apps/environment-variable.html.md.erb
+++ b/deploy-apps/environment-variable.html.md.erb
@@ -18,6 +18,11 @@ For information about setting your own app-specific environment variables, see t
 <span class="note__title"><strong>Important</strong></span>
 Do not use user-provided environment variables for security-sensitive information such as credentials. They might unintentionally show up in cf CLI output and Cloud Controller logs. Use <a href="../services/user-provided.html">user-provided service instances</a> instead. The system-provided environment variable <a href="#VCAP_SERVICES">VCAP_SERVICES</a> is properly redacted for user roles such as Space Supporter and in Cloud Controller log files.</p>
 
+<p class="note important">
+<span class="note__title"><strong>Important</strong></span>
+The maximum size of an environment variable is 130&nbsp;KB. This limit applies also to <%= vars.app_runtime_abbr %> system environment variables such as `VCAP_SERVICES` and `VCAP_APPLICATION`.</p>
+</p>
+
 ## <a id='view-env'></a> View environment variables
 
 Using the Cloud Foundry Command Line Interface (cf CLI), you can run the `cf env` command to view the <%= vars.app_runtime_abbr %> environment variables for your app. The `cf env` command displays the following environment variables:

--- a/deploy-apps/large-app-deploy.html.md.erb
+++ b/deploy-apps/large-app-deploy.html.md.erb
@@ -24,7 +24,7 @@ To deploy large apps to <%= vars.app_runtime_abbr %>, ensure that:
 
 * If you use an app manifest file, `manifest.yml`, specify adequate values for your app for attributes such as app memory, app start timeout, and disk space allocation. For more information about using app manifests, see [Deploying with app manifests](manifest.html).
 
-* The total size of environment variables for your app does not exceed 130&nbsp;KB. This includes <%= vars.app_runtime_abbr %> system environment variables such as `VCAP_SERVICES` and `VCAP_APPLICATION`. For more information, see [<%= vars.app_runtime_abbr %> environment variables](environment-variable.html).
+* The size of each environment variable for your app does not exceed 130&nbsp;KB. This includes <%= vars.app_runtime_abbr %> system environment variables such as `VCAP_SERVICES` and `VCAP_APPLICATION`. For more information, see [<%= vars.app_runtime_abbr %> environment variables](environment-variable.html).
 
 * You push only the files that are necessary for your app. To meet this requirement, push only the directory for your app, and remove unneeded files or use the `.cfignore` file to specify excluded files. For more information about specifying excluded files, see [Ignore unnecessary files when pushing](prepare-to-deploy.html#exclude) in _Considerations for Designing and Running an App in the Cloud_.
 


### PR DESCRIPTION
With cflinuxfs4 (Ubunut 22.04) the 130k limit for env vars is per env var and not anymore for all env vars.