### PR TITLE
Fix formatting within html note

### DIFF
--- a/deploy-apps/environment-variable.html.md.erb
+++ b/deploy-apps/environment-variable.html.md.erb
@@ -20,7 +20,7 @@ Do not use user-provided environment variables for security-sensitive informatio
 
 <p class="note important">
 <span class="note__title"><strong>Important</strong></span>
-The maximum size of an environment variable is 130&nbsp;KB. This limit applies also to <%= vars.app_runtime_abbr %> system environment variables such as `VCAP_SERVICES` and `VCAP_APPLICATION`.</p>
+The maximum size of an environment variable is 130&nbsp;KB. This limit applies also to <%= vars.app_runtime_abbr %> system environment variables such as <code>VCAP_SERVICES</code> and <code>VCAP_APPLICATION</code>.</p>
 </p>
 
 ## <a id='view-env'></a> View environment variables


### PR DESCRIPTION
- <code> tags instead of markdown backticks