### PR TITLE
Update manifest-attributes.html.md.erb

### DIFF
--- a/deploy-apps/manifest-attributes.html.md.erb
+++ b/deploy-apps/manifest-attributes.html.md.erb
@@ -292,7 +292,7 @@ Within the manifest, the health check invocation timeout is controlled by the `h
 
 ### <a id='health-check-interval'></a> health-check-interval
 
-The `health-check-interval` attribute specifies the amount of time in seconds between starting individual health check requests for HTTP and port health checks.
+The `health-check-interval` attribute specifies the amount of time in seconds between starting individual health check requests for HTTP and port health checks. The default value is 30.
 
 For example:
 

--- a/deploy-apps/manifest-attributes.html.md.erb
+++ b/deploy-apps/manifest-attributes.html.md.erb
@@ -292,7 +292,7 @@ Within the manifest, the health check invocation timeout is controlled by the `h
 
 ### <a id='health-check-interval'></a> health-check-interval
 
-The `health-check-interval` attribute specifies the amount of time in seconds between starting individual health check requests for HTTP and port health checks. The default value is 30.
+The `health-check-interval` attribute specifies the time in seconds between starting individual health check requests for HTTP and port health checks. The default value is 30.
 
 For example:
 


### PR DESCRIPTION
Adding default value to the "readiness-health-check-interval" into the the "App manifest attribute reference" documentation. We've tested this on a staging landscape.