### PR TITLE
docs: Adjust the syslog drain docs

### DIFF
--- a/services/user-provided.html.md.erb
+++ b/services/user-provided.html.md.erb
@@ -46,6 +46,11 @@ After creating the user-provided service instance, to deliver the credentials to
 
 User-provided service instances allow developers to stream app logs to a syslog compatible aggregation or analytics service that isn't available in the Marketplace. For more information about the syslog protocol see [RFC 5424](http://tools.ietf.org/html/rfc5424) and [RFC 6587](http://tools.ietf.org/html/rfc6587).
 
+<p class="note important">
+<span class="note__title"><strong>Important</strong></span>
+RFC-5424 is used to establish connections over http/ https. RFC-6587 is used for TCP based communication over syslog/syslog-tls drains.
+</p>
+
 Create the user-provided service instance, specifying the URL of the service with the `-l` option.
 
 <pre class="terminal">

--- a/services/user-provided.html.md.erb
+++ b/services/user-provided.html.md.erb
@@ -48,7 +48,7 @@ User-provided service instances allow developers to stream app logs to a syslog 
 
 <p class="note important">
 <span class="note__title"><strong>Important</strong></span>
-RFC-5424 is used to establish connections over http/ https. RFC-6587 is used for TCP based communication over syslog/syslog-tls drains.
+RFC-5424 is used to establish connections over HTTP/HTTPS. RFC-6587 is used for TCP based communication over syslog/syslog-tls drains.
 </p>
 
 Create the user-provided service instance, specifying the URL of the service with the `-l` option.


### PR DESCRIPTION
- The PR adds a note about the usage of RFC-5424 on HTTP/ HTTPS and RFC-6587 on TCP connections.

**Result:**
![Screenshot 2024-07-05 at 15 45 18](https://github.com/cloudfoundry/docs-dev-guide/assets/13447634/8fa7439b-54e6-4a30-9202-bc0abc5eec6e)