### PR TITLE
Update client-libraries.html.md.erb

### DIFF
--- a/capi/client-libraries.html.md.erb
+++ b/capi/client-libraries.html.md.erb
@@ -32,14 +32,11 @@ While you can develop apps that use CAPI by calling it directly as in the API do
 
 The following client is experimental and is a work in progress:
 
-* [Golang](https://godoc.org/github.com/cloudfoundry/cli/api/cloudcontroller)
+* [Golang](https://github.com/cloudfoundry/go-cfclient)
 
 ### <a id='unofficial'></a>Unofficial
 
 <%= vars.app_runtime_abbr %> does not support the following clients, but might be supported by third parties:
 
-* Golang:
-   * [cloudfoundry-community/go-cfclient](https://github.com/cloudfoundry-community/go-cfclient)
 * Python:
    * [cloudfoundry-community/cf-python-client](https://github.com/cloudfoundry-community/cf-python-client)
-   * [hsdp/python-cf-api](https://github.com/hsdp/python-cf-api)


### PR DESCRIPTION
- go-client moved from cloudfoundry-community into ARI WG and is therefore supported
- removed hopelessly outdated client libs