### PR TITLE
Add new/stopped app limitation for deployments

### DIFF
--- a/deploy-apps/canary-deploy.html.md.erb
+++ b/deploy-apps/canary-deploy.html.md.erb
@@ -297,6 +297,12 @@ The following table describes the limitations of when using canary deployments.
       Using CF CLI the logs can be retrieved using "cf logs APP_NAME" and search for "revision version"
     </td>
   </tr>
+  <tr>
+    <td>New or stopped applications</td>
+    <td>
+      When pushing an application for the first time, or if the app is stopped, no deployment strategy is used and all application instances are started immediately.
+    </td>
+  </tr>
 </table>
 
 

--- a/deploy-apps/rolling-deploy.html.md.erb
+++ b/deploy-apps/rolling-deploy.html.md.erb
@@ -299,6 +299,12 @@ The following table describes the limitations of when using rolling deployments.
     like <code>Cannot scale this process while a deployment is in flight.</code>. For more information, see <a href="https://v3-apidocs.cloudfoundry.org/version/3.109.0/index.html#scale-a-process">Scale a process</a>
     or <a href="https://v3-apidocs.cloudfoundry.org/version/3.109.0/index.html#update-a-process">Update a process</a> in the CAPI V3 documentation.</td>
   </tr>
+  <tr>
+    <td>New or stopped applications</td>
+    <td>
+      When pushing an application for the first time, or if the app is stopped, no deployment strategy is used and all application instances are started immediately.
+    </td>
+  </tr>
 </table>
 
 


### PR DESCRIPTION
This should be backported to any TAS versions with either of these files. Rolling deployments pre-dates canary, so it maybe the case you need to split this commit.