### PR TITLE
Per-route options: Fix the formatting of the console output

### DIFF
--- a/custom-per-route-options.html.md.erb
+++ b/custom-per-route-options.html.md.erb
@@ -45,7 +45,7 @@ To configure per-route load balancing for an application that has not yet been p
 
 1. Push the app with the manifest:
 
-    ```
+    ```console
     cf push -f manifest.yml
     ```
 
@@ -55,7 +55,7 @@ To change the per-route `loadbalancing` option of an existing route, you can use
 
 For example, to change an app route's algorithm from `least-connection` to `round-robin`, you can run the `update-route` command:
 
-    ```
+    ```console
     cf update-route EXAMPLE.COM --host MY-HOST --option loadbalancing=round-robin
     ```
 
@@ -63,7 +63,7 @@ Alternatively, it is also possible to update the per-route load balancing option
 
 Run the `PATCH` request to the targeted API endpoint:
 
-    ```
+    ```console
     cf curl /v3/routes/GUID -X PATCH -H "Content-type: application/json" \
       -d '{
         "options": {
@@ -79,13 +79,13 @@ Run the `PATCH` request to the targeted API endpoint:
 To create a route with a per-route `loadbalancing` option, you can use the cli command `create-route`. 
 For example:
 
-    ```
+    ```console
     cf create-route EXAMPLE.COM --host MY-HOST --option loadbalancing=round-robin
     ```
 
 Alternatively, it is also possible to create a route with a per-route load balancing option via the `/v3/routes` API:
 
-    ```
+    ```console
     cf curl /v3/routes -X POST -H "Content-type: application/json" \
       -d '{
         "host": "MY-HOST",
@@ -103,7 +103,7 @@ To create and map a new route to an existing application with the per-route `loa
 
 For example:
 
-    ```
+    ```console
     cf map-route MY-APP EXAMPLE.COM --hostname MY-HOST --option loadbalancing=round-robin
     ```
 
@@ -115,26 +115,26 @@ To update an existing route, the command <code>update-route</code> must be used 
 
 To read route options, you can query the route using the `route` command:
 
-    ```
+    ```console
     cf route EXAMPLE.COM --hostname MY-HOST
     ```
 
    The response lists the chosen `loadbalancing` algorithm option, e.g. `least-connection`:
 
-    ```
+    ```console
     options: {loadbalancing=least-connection}
     ```
 
    Alternatively, you can query the `routes` API endpoint for a route:
 
-    ```
+    ```console
     cf curl /v3/routes/?hosts=MY-HOST
     ```
 
     Where `MY-HOST` is the host attribute of the route. The response lists the chosen `loadbalancing` algorithm option as well:
 
-    ```
+    ```console
        "options": {"loadbalancing": "least-connection"}
     ```
 
-To retrieve all the routes with the corresponding options in a space of an organization, you can use `routes` command.
+To retrieve all the routes with the corresponding options in a space of an organization, you can use the `routes` command.


### PR DESCRIPTION
The console output blocks were specified incorrectly.