### PR TITLE
Fix the page "Delivering service credentials to an app"

### DIFF
--- a/services/application-binding.html.md.erb
+++ b/services/application-binding.html.md.erb
@@ -148,7 +148,7 @@ Service Binding Files:
   foo/binding-guid: 45436ca8-0a7c-45e3-9439-ca1b44db7a2b
 ```
 
-Binding names must match [a-z0-9\-.]{1,253}. Keys resulting in filenames must match [a-z0-9\-._]{1,253}. Invalid binding names and keys result in an <code>IncompatibleBindings</code> error.
+Binding names must match `[a-z0-9\-.]{1,253}`. Keys resulting in filenames must match `[a-z0-9\-._]{1,253}`. Invalid binding names and keys result in an <code>IncompatibleBindings</code> error.
 
 ### <a id='arbitrary-params-binding'></a> Arbitrary parameters
 


### PR DESCRIPTION
* underscore interferes with \<code\> section
* should fix currently broken page https://docs.cloudfoundry.org/devguide/services/application-binding.html