### PR TITLE
Clarify open source and commercial EOL of v2 endpoints

### DIFF
--- a/capi/client-libraries.html.md.erb
+++ b/capi/client-libraries.html.md.erb
@@ -13,6 +13,11 @@ platform. You can use it to manage orgs, spaces, and apps, which includes user r
 
 <%= vars.capi_link %>
 
+### CAPI v2 Deprecation and End of Life
+CAPI v2 endpoints are deprecated in both Open Source Cloud Foundry since 2021 and <%= vars.app_runtime_abbr %> in version 6.0 and forward. Given these endpoints are deprecated, new development should use the v3 endpoints. 
+Open Source Cloud Foundry has plans to end of life the v2 endpoints following this RFC: https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0032-cfapiv2-eol.md
+<%= vars.app_runtime_abbr %> does not have plans to end of life the V2 endpoints in the current LTS releases.
+
 ## <a id='client-libraries'></a>Client libraries
 
 While you can develop apps that use CAPI by calling it directly as in the API documentation, you might want to use an existing client library. See the following available client libraries.


### PR DESCRIPTION
Can this be added to the TPCF 10.2, 10.3, and forward releases?