### PR TITLE
[TCF-104] Fix legacy CF CLI URL prefix and variable in dev guide topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,17 @@ Create and publish free or metered services for Cloud Foundry apps.
 
 ## Branch map
 
-The docs is published through the [docs-book-application-service](https://github.gwd.broadcom.net/TNZ/docs-book-application-service) repository.
-
-| Branch  | EART version  | Doc Link      |
-|---------|---------------|---------------|
-| tcf-104 | EART 10.4     | [EART v10.4 staging](https://author-techdocs2-prod.adobecqms.net/us/en/vmware-tanzu/platform/elastic-application-runtime/10-4/eart/runtime-rn.html)
-| tcf-103 | EART 10.3     | [EART v10.3](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/elastic-application-runtime/10-3/eart/concepts-overview.html) |
-| tcf-102 | TPCF 10.2     | [TPCF v10.2](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/elastic-application-runtime/10-2/eart/concepts-overview.html) |
-| tcf-10  | TPCF 10.0     | archived PDF |
-| TAS-6.0 | TAS 6.0       | [TAS v6.0](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/elastic-application-runtime/6-0/eart/concepts-overview.html) |
-| TAS-5.0 | TAS 5.0       | archived PDF  |
-| 22.0    | TAS 4.0       | archived PDF  |
+| Branch  | EART version     | Doc Link      |
+|---------|------------------|---------------|
+| 10.5    | EART 10.5        | [EART v10.5 staging](https://author-techdocs2-prod.adobecqms.net/us/en/vmware-tanzu/platform/elastic-application-runtime/10-5/eart/runtime-rn.html)
+| tcf-104 | EART 10.4        | [EART v10.4](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/elastic-application-runtime/10-4/eart/runtime-rn.html)
+| tcf-103 | EART 10.3        | [EART v10.3](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/elastic-application-runtime/10-3/eart/concepts-overview.html) |
+| tcf-102 | TPCF 10.2        | [TPCF v10.2](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/elastic-application-runtime/10-2/eart/concepts-overview.html) |
+| tcf-10  | TPCF 10.0        | archived PDF |
+| 6.0     | TAS 6.0          | [TAS v6.0](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/elastic-application-runtime/6-0/eart/concepts-overview.html) |
+| 5.0     | TAS 5.0 (EOGS)   | archived PDF  |
+| 4.0     | TAS v4.0 (EOGS)  | archived PDF  |
+| 3.0     | TAS v3.0 (EOGS)  | archived PDF  |
+| 2.13    | TAS v2.13 (EOGS) | archived PDF  |
+| 2.12    | TAS v2.12 (EOGS) | archived PDF  |
+| 2.11    | TAS v2.11 (EOGS) | archived PDF  |

--- a/deploy-apps/cf-networking.html.md.erb
+++ b/deploy-apps/cf-networking.html.md.erb
@@ -28,7 +28,7 @@ Ensure that you are using Tanzu cf CLI v10 or later:
 $ cf version
 </pre>
 
-For more information about updating the cf CLI, see [Upgrading to Tanzu cf CLI v10](https://techdocs.broadcom.com/content/broadcom/techdocs/us/en/vmware-tanzu/platform/tanzu-cf-cli/<%= vars.current_major_version_url %>/t-cf-cli/cf-cli-v10.html).
+For more information about updating the cf CLI, see [Upgrading to Tanzu cf CLI v10](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-cf-cli/<%= vars.tanzu_cf_cli_version %>/t-cf-cli/cf-cli-v10.html).
 
 
 ### <a name="grant"></a> Grant permissions

--- a/deploy-apps/push-docker.html.md.erb
+++ b/deploy-apps/push-docker.html.md.erb
@@ -3,7 +3,7 @@ title: Deploying an app based on a Docker image
 owner: Diego
 ---
 
-You can use the [Tanzu cf CLI](https://techdocs.broadcom.com/content/broadcom/techdocs/us/en/vmware-tanzu/platform/tanzu-cf-cli/<%= vars.current_major_version_url %>/t-cf-cli/install-cf-cli.html) to push an app with a new or updated Docker image. <%= vars.app_runtime_first %> then uses the Docker image to create containers for the app.
+You can use the [Tanzu cf CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-cf-cli/<%= vars.tanzu_cf_cli_version %>/t-cf-cli/install-cf-cli.html) to push an app with a new or updated Docker image. <%= vars.app_runtime_first %> then uses the Docker image to create containers for the app.
 
 <%= vars.using_docker_link %>
 

--- a/deploy-apps/ssh-apps.html.md.erb
+++ b/deploy-apps/ssh-apps.html.md.erb
@@ -7,7 +7,7 @@ owner: Diego
 The Tanzu cf CLI lets you securely log in to remote host virtual machines (VMs) running <%= vars.app_runtime_full %> (<%= vars.app_runtime_abbr %>) app instances. The commands that activate SSH access to apps, and activate, deactivate, and verify permissions for such access are described here.
 
 <p class="note important">
-The <code>cf ssh</code> command in cf CLI include the <code>all_proxy</code> environment variable, which allows you to specify a proxy server to activate proxying for all requests. For more information, see <a href="https://techdocs.broadcom.com/content/broadcom/techdocs/us/en/vmware-tanzu/platform/tanzu-cf-cli/<%= vars.current_major_version_url %>/t-cf-cli/http-proxy.html#v3-ssh-socks5">Use SOCKS5 with cf v3-ssh</a> in <em>Using the cf CLI with a proxy server</em>
+The <code>cf ssh</code> command in cf CLI include the <code>all_proxy</code> environment variable, which allows you to specify a proxy server to activate proxying for all requests. For more information, see <a href="https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-cf-cli/<%= vars.tanzu_cf_cli_version %>/t-cf-cli/http-proxy.html#v3-ssh-socks5">Use SOCKS5 with cf v3-ssh</a> in <em>Using the cf CLI with a proxy server</em>
 <br>For details about the <code>cf ssh</code> command, enter <code>cf ssh --help</code>.</p>
 
 The Tanzu cf CLI looks up the `app_ssh_oauth_client` identifier in the Cloud Controller `/v2/info` endpoint, and uses this identifier to query the Tanzu UAA server for an SSH authorization code. On the target VM side, the SSH proxy contacts the Cloud Controller through the `app_ssh_endpoint` listed in `/v2/info` to confirm permission for SSH access.

--- a/deploy-apps/stop-delete.html.md.erb
+++ b/deploy-apps/stop-delete.html.md.erb
@@ -6,7 +6,7 @@ owner: CLI
 
 You can stop and delete your apps using Tanzu cf CLI commands.
 
-To run the commands shown here, you must first install the Tanzu cf CLI. See the [Using the Tanzu cf CLI](https://techdocs.broadcom.com/content/broadcom/techdocs/us/en/vmware-tanzu/platform/tanzu-cf-cli/<%= vars.current_major_version_url %>/t-cf-cli/index.html) topics for more information.
+To run the commands shown here, you must first install the Tanzu cf CLI. See the [Using the Tanzu cf CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-cf-cli/<%= vars.tanzu_cf_cli_version %>/t-cf-cli/index.html) topics for more information.
 
 ## <a id="stop-start"></a> Stop and start an app
 

--- a/services/managing-services.html.md.erb
+++ b/services/managing-services.html.md.erb
@@ -7,7 +7,7 @@ owner: Core Services
 
 You can manage life cycle operations for service instances using the Tanzu cf CLI. This includes creating, updating, and deleting service instances. For information about other service management operations, see [Services overview](./index.html). <%= vars.custom_services %>
 
-To run the commands in this topic, you must first install the Tanzu cf CLI. See the [Using the Tanzu cf CLI](https://techdocs.broadcom.com/content/broadcom/techdocs/us/en/vmware-tanzu/platform/tanzu-cf-cli/<%= vars.current_major_version_url %>/t-cf-cli/index.html) topics for more information.
+To run the commands in this topic, you must first install the Tanzu cf CLI. See the [Using the Tanzu cf CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-cf-cli/<%= vars.tanzu_cf_cli_version %>/t-cf-cli/index.html) topics for more information.
 
 ## <a id='marketplace'></a> List Marketplace services
 


### PR DESCRIPTION
## Summary

Companion to TNZ/docs-operating-pas#95. Fixes the legacy CF CLI external link prefix in five dev guide topic files.

- Removes the legacy `/content/broadcom/techdocs` URL prefix
- Switches `vars.current_major_version_url` to `vars.tanzu_cf_cli_version`

**Files changed:**
- `deploy-apps/cf-networking.html.md.erb`  
- `deploy-apps/push-docker.html.md.erb`  
- `services/managing-services.html.md.erb`  
- `deploy-apps/stop-delete.html.md.erb`  
- `deploy-apps/ssh-apps.html.md.erb`  

## Merge order

Independent of docs-operating-pas#95; can be merged at any time.

ai-assisted=yes
TNZ-95042