### PR TITLE
Add staging memory and disk minimums to large app deploy doc

### DIFF
--- a/deploy-apps/large-app-deploy.html.md.erb
+++ b/deploy-apps/large-app-deploy.html.md.erb
@@ -84,6 +84,14 @@ The following table provides a summary of the constraints and default settings t
     <td>Default: 1024&nbsp;MB</td>
   </tr>
   <tr>
+    <td>Minimum staging memory</td>
+    <td>Default: 1024&nbsp;MB</td>
+  </tr>
+  <tr>
+    <td>Minimum staging disk space</td>
+    <td>Default: 4096&nbsp;MB</td>
+  </tr>
+  <tr>
     <td>Internet connection speed</td>
     <td>Recommended minimum: 874&nbsp;KB per second</td>
   </tr>


### PR DESCRIPTION
Document the minimum resources for staging tasks in the default settings and limitations summary table.