### PR TITLE
Add cflinuxfs5 to available stacks documentation

### DIFF
--- a/deploy-apps/stacks.html.md.erb
+++ b/deploy-apps/stacks.html.md.erb
@@ -30,7 +30,7 @@ Docker apps do not use stacks.</p>
 Cloud Foundry supports the following Linux stacks:
 
 - `cflinuxfs4` (default), derived from Ubuntu 22.04 LTS (Jammy Jellyfish). For more information, see [GitHub cflinuxfs4 stack receipt](https://github.com/cloudfoundry/cflinuxfs4/blob/main/receipt.cflinuxfs4.x86_64).
-- `cflinuxfs5`, derived from Ubuntu 24.04 LTS (Noble Numbat). Operators can enable this stack alongside `cflinuxfs4` by applying the [`add-cflinuxfs5.yml`](https://github.com/cloudfoundry/cf-deployment/blob/main/operations/experimental/add-cflinuxfs5.yml) experimental ops file from `cf-deployment`. For more information, see [GitHub cflinuxfs5 stack receipt](https://github.com/cloudfoundry/cflinuxfs5/blob/main/receipt.cflinuxfs5.x86_64).
+- `cflinuxfs5`, derived from Ubuntu 24.04 LTS (Noble Numbat). Operators can enable this stack alongside `cflinuxfs4` by applying the [add-cflinuxfs5.yml](https://github.com/cloudfoundry/cf-deployment/blob/main/operations/experimental/add-cflinuxfs5.yml) experimental ops file from `cf-deployment`. For more information, see [GitHub cflinuxfs5 stack receipt](https://github.com/cloudfoundry/cflinuxfs5/blob/main/receipt.cflinuxfs5.x86_64).
 
 To list the stacks available in your foundation, run `cf stacks`.
 

--- a/deploy-apps/stacks.html.md.erb
+++ b/deploy-apps/stacks.html.md.erb
@@ -27,7 +27,12 @@ Docker apps do not use stacks.</p>
 
 ## <a id='available-stacks'></a> Available stacks
 
-Cloud Foundry includes support for `cflinuxfs4`, which is derived from Ubuntu 22.04 LTS (Jammy Jellyfish). For more information, see [GitHub cflinuxfs4 stack receipt](https://github.com/cloudfoundry/cflinuxfs4/blob/main/receipt.cflinuxfs4.x86_64).
+Cloud Foundry supports the following Linux stacks:
+
+- `cflinuxfs4` (default), derived from Ubuntu 22.04 LTS (Jammy Jellyfish). For more information, see [GitHub cflinuxfs4 stack receipt](https://github.com/cloudfoundry/cflinuxfs4/blob/main/receipt.cflinuxfs4.x86_64).
+- `cflinuxfs5`, derived from Ubuntu 24.04 LTS (Noble Numbat). Operators can enable this stack alongside `cflinuxfs4` by applying the [`add-cflinuxfs5.yml`](https://github.com/cloudfoundry/cf-deployment/blob/main/operations/experimental/add-cflinuxfs5.yml) experimental ops file from `cf-deployment`. For more information, see [GitHub cflinuxfs5 stack receipt](https://github.com/cloudfoundry/cflinuxfs5/blob/main/receipt.cflinuxfs5.x86_64).
+
+To list the stacks available in your foundation, run `cf stacks`.
 
 You can also build your own custom stack. For more information, see [Adding a Custom Stack](../../running/custom-stack.html).
 
@@ -61,6 +66,7 @@ To restage an app on a new stack:
     Getting stacks in org MY-ORG / space development as developer@example.com...
 
     name        description                                                    state
+    cflinuxfs5  Cloud Foundry Linux-based filesystem (Ubuntu 24.04)            ACTIVE
     cflinuxfs4  Cloud Foundry Linux-based filesystem (Ubuntu 22.04)            ACTIVE
     cflinuxfs3  Cloud Foundry Linux-based filesystem (Ubuntu 18.04)            DEPRECATED
     </pre>


### PR DESCRIPTION
## Summary

Document the `cflinuxfs5` stack (derived from Ubuntu 24.04 LTS "Noble Numbat") as an additional Linux stack available in Cloud Foundry.

## Changes

- Reword **Available stacks** section into a list, documenting both `cflinuxfs4` (default) and `cflinuxfs5`.
- Note that `cflinuxfs5` is currently enabled via the [`add-cflinuxfs5.yml`](https://github.com/cloudfoundry/cf-deployment/blob/main/operations/experimental/add-cflinuxfs5.yml) experimental ops file in `cf-deployment`, while `cflinuxfs4` remains the default.
- Link to the [`cflinuxfs5` stack receipt](https://github.com/cloudfoundry/cflinuxfs5/blob/main/receipt.cflinuxfs5.x86_64).
- Update the sample `cf stacks` output to include `cflinuxfs5` as `ACTIVE`.

## Why

Application developers currently have no way to learn from the official docs that `cflinuxfs5` exists or how it can be enabled in their foundation. The stack rootfs (`cloudfoundry/cflinuxfs5`) and the BOSH release (`cloudfoundry/cflinuxfs5-release`) are published, and the experimental ops file in `cf-deployment` allows operators to opt in today.

## Notes

- This PR is intentionally conservative: `cflinuxfs5` is described as opt-in via the experimental ops file. Once `cflinuxfs5` is promoted directly into `cf-deployment.yml` (as planned), a follow-up PR should drop the "experimental" wording.
- No changes to `windows-stacks.html.md.erb`.
