### PR TITLE
Docs: cross-link identity-aware routing from instance-identity page (RFC-0055)

### DIFF
--- a/deploy-apps/instance-identity.html.md.erb
+++ b/deploy-apps/instance-identity.html.md.erb
@@ -22,3 +22,5 @@ The Diego Cell rep supplies a new certificate and private keypair to the app ins
 * If the validity period is less than or equal to 4 hours, the pair regenerates between 1/4 and 1/12 of the time to the end of the period.
 
 For more information about enabling and configuring the Instance Identity system in Cloud Foundry, see [Enabling Instance Identity](https://docs.cloudfoundry.org/adminguide/instance-identity.html).
+
+For information about using instance identity certificates for app-to-app routing through the Gorouter with platform-enforced authorization, see [Configuring identity-aware routing](identity-aware-routing.html).


### PR DESCRIPTION
## Summary

Adds a cross-reference at the end of `deploy-apps/instance-identity.html.md.erb` linking to the identity-aware routing developer how-to. The same `CF_INSTANCE_CERT`/`CF_INSTANCE_KEY` credentials and Subject OUs (app, space, org GUIDs) documented on this page are used by identity-aware routing to authenticate callers at the Gorouter.

## References

- RFC-0055: https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0055-identity-aware-routing-for-gorouter.md
- Developer how-to PR: cloudfoundry/docs-dev-guide#594