### PR TITLE
Remove deprecated -n flag from blue-green deployment examples

### DIFF
--- a/deploy-apps/blue-green.html.md.erb
+++ b/deploy-apps/blue-green.html.md.erb
@@ -79,7 +79,7 @@ requests go to both the Green app and the Blue app.
 Use the `cf map-route` command to map the original URL route (`demo-time.example.com`) to the Green app.
 
 <pre class="terminal">
-$ cf map-route Green example.com -n demo-time
+$ cf map-route Green example.com --hostname demo-time
 Binding demo-time.example.com to Green... OK
 </pre>
 
@@ -96,7 +96,7 @@ After you verify that Green is running as expected, stop routing requests to Blu
 using the `cf unmap-route` command:
 
 <pre class="terminal">
-$ cf unmap-route Blue example.com -n demo-time
+$ cf unmap-route Blue example.com --hostname demo-time
 Unbinding demo-time.example.com from blue... OK
 </pre>
 


### PR DESCRIPTION
## Summary

- Replaces `cf map-route ... -n` and `cf unmap-route ... -n` with `--hostname` (long form) in the blue-green deployment example
- The `-n` shorthand for `--hostname` was removed in cf CLI v7; cf CLI v8 is the current version

Fixes #511

## Test plan

- [ ] Verify Steps 3 and 4 terminal blocks show `--hostname demo-time` with no `-n` flag
- [ ] Confirm no other `-n` flags remain in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)