### PR TITLE
Remove platform-conditional ERB blocks, keep OSS content [ai-assisted]

### DIFF
--- a/capi/client-libraries.html.md.erb
+++ b/capi/client-libraries.html.md.erb
@@ -3,12 +3,7 @@ title: Available Cloud Controller API client libraries
 owner: CAPI
 ---
 
-Here is a list of the client libraries you can use with the Cloud Foundry API (CAPI)
-<% if vars.platform_code == "CF" %>
-.
-<% else %>
- for <%= vars.app_runtime_first %>.
-<% end %>
+Here is a list of the client libraries you can use with the Cloud Foundry API (CAPI).
 
 ## <a id='overview'></a>CAPI overview
 

--- a/custom-ports.html.md.erb
+++ b/custom-ports.html.md.erb
@@ -3,14 +3,6 @@ title: Configuring Cloud Foundry to route traffic to apps on custom ports
 owner: CF for VMs Networking
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("Configuring", vars.app_runtime_abbr, "to Route Traffic to Apps on Custom Ports") %>
-
-<% end %>
-
-
 By default, apps only receive requests on port `8080` for both HTTP and TCP routing. Configuring custom app ports allows developers to bring workloads onto
 <%= vars.app_runtime_abbr %> that receive requests on ports other than `8080`. Here are some example use cases:
 

--- a/deploy-apps/app-lifecycle.html.md.erb
+++ b/deploy-apps/app-lifecycle.html.md.erb
@@ -43,11 +43,7 @@ During app duplication, singleton app instances might become temporarily unavail
 To stop the app, <%= vars.app_runtime_abbr %> sends the app process in the container a SIGTERM. By default, the process has ten seconds to shut down gracefully. If the process has not exited after ten seconds, <%= vars.app_runtime_abbr %> sends a SIGKILL.
 
 By default, apps must finish their in-flight jobs within ten seconds of receiving the SIGTERM before <%= vars.app_runtime_abbr %> stops the app with a SIGKILL. For example, a web app must finish processing existing requests and stop accepting new requests.
-<% if vars.platform_code == 'PCF' %>
-  To change the timeout period on the <%= vars.app_runtime_abbr %> tile or IST tile, go to the <strong>Advanced Settings</strong> tab and edit the "app graceful shutdown period" property.
-<% else %>
 To change the timeout period, change the BOSH property <code>containers.graceful_shutdown_interval_in_seconds</code> on the replacement jobs.
-<% end %>
 This might increase the time it takes to drain Diego Cells, which causes increased deployment time.
 
 <%= vars.app_graceful_shutdown_config %>

--- a/deploy-apps/cf-networking.html.md.erb
+++ b/deploy-apps/cf-networking.html.md.erb
@@ -13,19 +13,11 @@ Container-to-container networking is not available for apps hosted on Microsoft 
 
 <%= vars.app_traffic_logging %>
 
-<% if vars.platform_code == "CF" %>
 <%= partial 'c2c_oss_enable' %>
-<% end %>
 
-<% if vars.platform_code == "CF" %>
 <%= partial 'c2c_oss_overlay' %>
-<% else %>
-<%= partial "/pcf/core/c2c_overlay" %>
-<% end %>
 
-<% if vars.platform_code == "CF" %>
 <%= partial 'c2c_oss_logging' %>
-<% end %>
 
 
 ## <a id="create-policies"></a> Create and manage networking policies
@@ -43,8 +35,6 @@ $ cf version
 </pre>
 
 For more information about updating the cf CLI, see [Installing the cf CLI](../../cf-cli/install-go-cli.html).
-
-<% if vars.platform_code == "CF" || vars.platform_code == "PCF" %>
 
 ### <a id="grant"></a> Grant permissions
 
@@ -76,19 +66,9 @@ To grant all Space Developers permissions to configure network policies, <%=  va
 
 By default, Space Developers can add a maximum of 150 network policies per
 source app.
-<% end %>
-<% if vars.platform_code == "PCF" %>
-Operators can increase this limit by changing the **Maximum number of network
-policies per app source** property in the **App Developer Controls** tab.
-<% end %>
-<% if vars.platform_code == "CF" %>
 Operators can change this limit by changing the `max_policies_per_app_source` property in the policy-server job in
 the Cloud Foundry deployment manifest.
-<% end %>
-<% if vars.platform_code == "CF" || vars.platform_code == "PCF" %>
 This limit does not apply to users with the network.admin scope.
-
-<% end %>
 
 ### <a id="add-policy"></a> Add a network policy
 
@@ -177,8 +157,6 @@ You can deactivate Silk network policy enforcement between apps. Deactivating ne
 
 To deactivate network policy enforcement between apps:
 
-<% if vars.platform_code == "CF" %>
-
 1. To target your BOSH deployment, run:
    <pre>
    bosh target -e MY-ENV -d MY-DEPLOYMENT
@@ -200,13 +178,6 @@ To deactivate network policy enforcement between apps:
    bosh -e MY-ENV -d MY-DEPLOYMENT deploy MY-MANIFEST.yml
    </pre>
 
-<% else %>
-
-<%= partial "/pcf/core/disable_network_policy_enforcement" %>
-
-<% end %>
-
-
 ## <a id="discovery"></a> App service discovery
 
 With app service discovery, apps pushed to <%= vars.app_runtime_abbr %> can establish container-to-container communications through a known route served by internal BOSH DNS. This allows front end apps to easily connect with back end apps.
@@ -224,10 +195,6 @@ See [Cats and Dogs with Service Discovery](https://github.com/cloudfoundry/cf-ne
 
 To use TLS developer adds a network policy for port 61443. After that the front end app can reach the back end app using HTTPS, `https://backend-app.apps.internal:61443`, for example.
 
-<% if vars.platform_code == "CF" %>
-
 ### <a id="enable-discovery"></a> Activate app service discovery
 
 To activate app service discovery, <%= vars.enable_c2c_discovery %>.
-
-<% end %>

--- a/deploy-apps/environment-variable.html.md.erb
+++ b/deploy-apps/environment-variable.html.md.erb
@@ -3,13 +3,6 @@ title: Cloud Foundry environment variables
 owner: CAPI
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title(vars.app_runtime_abbr, "Environment Variables") %>
-
-<% end %>
-
 Environment variables are the means <%= vars.app_runtime_abbr %> uses to communicate with a deployed app about its environment.
 
 For information about setting your own app-specific environment variables, see the [Environment variable](./manifest.html#env-block) in _Deploying with app manifests_.

--- a/deploy-apps/ssh-apps.html.md.erb
+++ b/deploy-apps/ssh-apps.html.md.erb
@@ -261,9 +261,7 @@ The SSH proxy has these SSH security configuration by default:
 
 The `cf ssh` command is compatible with this security configuration. If you use a different SSH client to access apps over SSH, you can ensure that you configure your client to be compatible with these ciphers, MACs, and key exchanges. For more information about other SSH clients, see [App SSH access without cf CLI](#other-ssh-access).
 
-<% if vars.platform_code == 'CF' %>
 Cloud Foundry deployment operators can also change these default values in the SSH proxy configuration. Changing these default values might require a change to the SSH client configuration.
-<% end %>
 
 
 ## <a id="proxy-to-container-auth"></a> Proxy to container authentication

--- a/deploy-apps/stacks.html.md.erb
+++ b/deploy-apps/stacks.html.md.erb
@@ -12,10 +12,7 @@ You can restage apps on a new stack. Here is a description of stacks and lists o
 
 To restage a Windows app on a new Windows stack, see [Changing Windows stacks](./windows-stacks.html).
 
-<% if vars.platform_code == "CF" || vars.platform_code == "PCF" %>
 You can also use the Stack Auditor plug-in for the Cloud Foundry Command Line Interface (cf CLI) when changing stacks. See [Using the Stack Auditor plug-in](../../adminguide/stack-auditor.html).
-<% else %>
-<% end %>
 
 ## <a id='overview'></a> Overview
 

--- a/deploy-apps/streaming-logs.html.md.erb
+++ b/deploy-apps/streaming-logs.html.md.erb
@@ -3,13 +3,6 @@ title: App logging in Cloud Foundry
 owner: PCF Metrics
 ---
 
-<%# Reset page title based on platform type %>
-<% if vars.platform_code != 'CF' %>
-
-<% set_title("App Logging in", vars.app_runtime_abbr) %>
-
-<% end %>
-
 Loggregator, the <%= vars.app_runtime_full %> (<%= vars.app_runtime_abbr %>) component responsible for logging, provides a stream of log output from your app and from <%= vars.app_runtime_abbr %> system components that interact with your app during updates and execution.
 
 

--- a/deploy-apps/windows-stacks.html.md.erb
+++ b/deploy-apps/windows-stacks.html.md.erb
@@ -10,10 +10,7 @@ This topic explains how you can restage apps on a new Windows stack. It also des
 
 To restage a Windows app on a new Linux stack, see [Changing stacks](./stacks.html).
 
-<% if vars.platform_code == "CF" || vars.platform_code == "PCF" %>
 You can also use the Stack Auditor plug-in for the Cloud Foundry Command Line Interface (cf CLI) when changing stacks. See [Using the Stack Auditor plug-in](../../adminguide/stack-auditor.html).
-<% else %>
-<% end %>
 
 ## <a id='overview'></a> Overview
 

--- a/egress-policies.html.md.erb
+++ b/egress-policies.html.md.erb
@@ -3,17 +3,6 @@ title: Topic does not exist
 owner: CF for VMs Networking
 ---
 
-<% if vars.platform_code == "CF" %>
-
 The topic that you were looking for, titled _Administering Dynamic Egress Policies_, does not exist.
 
 The feature this topic covers is removed.
-
-<% else %>
-
-The topic that you were looking for does not exist in this version of the <%= vars.product_full %> documentation.
-The feature this topic covers is removed.
-
-The topic _Administering Dynamic Egress Policies_ is available in <%= vars.product_full %> v2.10.
-
-<% end %>

--- a/revisions.html.md.erb
+++ b/revisions.html.md.erb
@@ -61,9 +61,7 @@ Each revision includes a description of what changed in your app at the time the
 
 By default, <%= vars.platform_name %> retains the five most recent staged droplets in its droplets bucket. This means that you can roll back to revisions as long as they are using one of those five droplets. Not all revisions include a change in droplet.
 
-<% if vars.platform_code == "CF" || vars.platform_code == "PCF" %>
 Operators can configure <%= vars.platform_name %> to retain more droplets if necessary using the <%= vars.droplet_config %>
-<% end %>
 
 
 ## <a id="view"></a> View revisions
@@ -197,12 +195,7 @@ To roll back to a previous revision:
 
 ## <a id="metadata"></a> Add metadata to a revision
 
-<% if vars.platform_code == "CF" || vars.platform_code == "PCF" %>
-
 To add metadata to a revision, see [Add metadata to an object](../adminguide/metadata.html).
-<% else %>
-To add metadata to a revision, see [Cloud Foundry documentation](https://docs.cloudfoundry.org/adminguide/metadata.html).
-<% end %>
 
 ## <a id="disable"></a> Deactivate revisions for an app
 

--- a/services/using-vol-services.html.md.erb
+++ b/services/using-vol-services.html.md.erb
@@ -3,12 +3,4 @@ title: Using an external file system (volume services)
 owner: Core Services
 ---
 
-<% if vars.platform_code == "PCF" || vars.platform_code == "CF" %>
-
 <%= partial 'using-vol-services' %>
-
-<% else %>
-
-<%= vars.vol_services_not_available %>
-
-<% end %>

--- a/using-tasks.html.md.erb
+++ b/using-tasks.html.md.erb
@@ -69,11 +69,7 @@ Admins can set the default memory, disk usage and log rate quotas for tasks on a
 Tasks use the same memory, disk usage, and log rate limit defaults as apps, unless you customize them using the `cf run-task` command.
 For more information about the `cf run-task` command, enter `cf help run-task`.
 
-<% if vars.platform_code == 'PCF' %>
-<%= partial "/pcf/core/tasks_rec_alloc_pcf" %>
-<% else %>
 <%= partial 'tasks_rec_alloc_oss' %>
-<% end %>
 
 
 ## <a id='run-tasks'></a> Run a task on an app


### PR DESCRIPTION
This repo is now dedicated exclusively to the OSS Cloud Foundry doc set, so the vars.platform_code conditionals that used to branch between CF and commercial (PCF) content no longer serve any purpose. Unwrap or delete each conditional, keeping only the CF/OSS-branch prose and partials.